### PR TITLE
fix: synchronize package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,26 @@
 {
     "name": "machine-lang",
-    "version": "0.2.2",
+    "version": "0.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "machine-lang",
-            "version": "0.2.2",
+            "version": "0.2.4",
             "dependencies": {
                 "@aws-sdk/client-bedrock-runtime": "^3.535.0",
+                "@codemirror/autocomplete": "^6.12.0",
+                "@codemirror/commands": "^6.3.3",
+                "@codemirror/language": "^6.10.0",
+                "@codemirror/lint": "^6.5.0",
+                "@codemirror/search": "^6.5.5",
+                "@codemirror/state": "^6.4.0",
+                "@codemirror/theme-one-dark": "^6.1.2",
+                "@codemirror/view": "^6.23.0",
                 "@codingame/monaco-vscode-editor-service-override": "~3.2.3",
                 "@codingame/monaco-vscode-keybindings-service-override": "~3.2.3",
                 "chalk": "~5.3.0",
+                "codemirror": "^6.0.1",
                 "commander": "~11.0.0",
                 "langium": "~3.4.0",
                 "mermaid": "^11.0.0",
@@ -708,6 +717,99 @@
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
             "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
+        },
+        "node_modules/@codemirror/autocomplete": {
+            "version": "6.19.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.19.0.tgz",
+            "integrity": "sha512-61Hfv3cF07XvUxNeC3E7jhG8XNi1Yom1G0lRC936oLnlF+jrbrv8rc/J98XlYzcsAoTVupfsf5fLej1aI8kyIg==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.17.0",
+                "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/commands": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.9.0.tgz",
+            "integrity": "sha512-454TVgjhO6cMufsyyGN70rGIfJxJEjcqjBG2x2Y03Y/+Fm99d3O/Kv1QDYWuG6hvxsgmjXmBuATikIIYvERX+w==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.4.0",
+                "@codemirror/view": "^6.27.0",
+                "@lezer/common": "^1.1.0"
+            }
+        },
+        "node_modules/@codemirror/language": {
+            "version": "6.11.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
+            "integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.23.0",
+                "@lezer/common": "^1.1.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.0.0",
+                "style-mod": "^4.0.0"
+            }
+        },
+        "node_modules/@codemirror/lint": {
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.0.tgz",
+            "integrity": "sha512-wZxW+9XDytH3SKvS8cQzMyQCaaazH8XL1EMHleHe00wVzsv7NBQKVW2yzEHrRhmM7ZOhVdItPbvlRBvMp9ej7A==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.35.0",
+                "crelt": "^1.0.5"
+            }
+        },
+        "node_modules/@codemirror/search": {
+            "version": "6.5.11",
+            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+            "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0",
+                "crelt": "^1.0.5"
+            }
+        },
+        "node_modules/@codemirror/state": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+            "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+            "license": "MIT",
+            "dependencies": {
+                "@marijn/find-cluster-break": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/theme-one-dark": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+            "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0",
+                "@lezer/highlight": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/view": {
+            "version": "6.38.4",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.4.tgz",
+            "integrity": "sha512-hduz0suCcUSC/kM8Fq3A9iLwInJDl8fD1xLpTIk+5xkNm8z/FT7UsIa9sOXrkpChh+XXc18RzswE8QqELsVl+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.5.0",
+                "crelt": "^1.0.6",
+                "style-mod": "^4.1.0",
+                "w3c-keyname": "^2.2.4"
+            }
         },
         "node_modules/@codingame/esbuild-import-meta-url-plugin": {
             "version": "1.0.3",
@@ -1432,6 +1534,36 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "dev": true
+        },
+        "node_modules/@lezer/common": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+            "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+            "license": "MIT"
+        },
+        "node_modules/@lezer/highlight": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+            "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@lezer/lr": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+            "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@marijn/find-cluster-break": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+            "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+            "license": "MIT"
         },
         "node_modules/@mermaid-js/parser": {
             "version": "0.3.0",
@@ -3229,6 +3361,21 @@
                 "node": ">=12"
             }
         },
+        "node_modules/codemirror": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+            "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/autocomplete": "^6.0.0",
+                "@codemirror/commands": "^6.0.0",
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/lint": "^6.0.0",
+                "@codemirror/search": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3352,6 +3499,12 @@
             "dependencies": {
                 "layout-base": "^1.0.0"
             }
+        },
+        "node_modules/crelt": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+            "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -6305,6 +6458,12 @@
                 }
             ]
         },
+        "node_modules/style-mod": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+            "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+            "license": "MIT"
+        },
         "node_modules/stylis": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
@@ -6783,6 +6942,12 @@
             "engines": {
                 "node": ">=14.0.0"
             }
+        },
+        "node_modules/w3c-keyname": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+            "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+            "license": "MIT"
         },
         "node_modules/whatwg-encoding": {
             "version": "2.0.0",


### PR DESCRIPTION
Update package-lock.json to include missing CodeMirror dependencies that were causing npm ci to fail in GitHub Pages deployment.

Fixes #4


Generated with [Claude Code](https://claude.ai/code)