### PR TITLE
Fix deployment build failures in HTML imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,8 +379,8 @@ ordering -involves-> supplier;</div>
 
     <script type="module">
         // vite is used to resolve the included TypeScript files
-        import { configureMonacoWorkers } from '../src/setupCommon';
-        import { executeExtended } from '../src/setupExtended';
+        import { configureMonacoWorkers } from './src/setupCommon.ts';
+        import { executeExtended } from './src/setupExtended.ts';
 
         configureMonacoWorkers();
         // keep a reference to a promise for when the editor is finished starting
@@ -390,10 +390,10 @@ ordering -involves-> supplier;</div>
             executeExtended(el, false, out);
             el.closest('.carousel-slide').appendChild(out)
         })
-        
+
 
         // Initialize carousels
-        import { initializeCarousels } from '../src/web';
+        import { initializeCarousels } from './src/web/index.ts';
         initializeCarousels();
     </script>
 </body>

--- a/playground-mobile.html
+++ b/playground-mobile.html
@@ -252,7 +252,7 @@
     </div>
 
     <script type="module">
-        import { setupCodeMirrorPlayground } from './src/codemirror-setup.js';
+        import { setupCodeMirrorPlayground } from './src/codemirror-setup.ts';
 
         // Initialize playground when DOM is ready
         document.addEventListener('DOMContentLoaded', () => {

--- a/playground.html
+++ b/playground.html
@@ -24,8 +24,8 @@
         <!-- Monaco Configuration -->
         <script type="module">
             // vite is used to resolve the included TypeScript files
-            import { configureMonacoWorkers } from '../src/setupCommon';
-            import { executeExtended } from '../src/setupExtended';
+            import { configureMonacoWorkers } from './src/setupCommon.ts';
+            import { executeExtended } from './src/setupExtended.ts';
 
             configureMonacoWorkers();
             // keep a reference to a promise for when the editor is finished starting


### PR DESCRIPTION
Fixed incorrect TypeScript module imports in HTML files that were causing the Vite build to fail during deployment.

### Changes
- playground-mobile.html: Changed codemirror-setup.js to .ts
- index.html: Fixed paths from ../src/ to ./src/ and added .ts extensions
- playground.html: Fixed paths from ../src/ to ./src/ and added .ts extensions

The build now completes successfully and generates the dist directory for deployment.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)