### PR TITLE
Add comprehensive documentation pages and update footer links

### DIFF
--- a/api.html
+++ b/api.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>API Reference | DyGram</title>
+    <link rel="stylesheet" href="static/styles/main.css">
+</head>
+<body>
+    <header style="height: auto; padding: 4rem 0;">
+        <div class="container">
+            <a href="index.html" style="color: var(--primary); text-decoration: none; font-size: 1.2rem;">← Back to Home</a>
+            <div class="title-block" style="margin-top: 2rem;">
+                API Reference<span class="accent">.</span>
+            </div>
+        </div>
+    </header>
+
+    <section>
+        <div class="container">
+            <h2 class="section-title">Programmatic API</h2>
+            <p style="font-size: 1.2rem; margin-bottom: 3rem;">
+                Use DyGram as a library in your Node.js applications.
+            </p>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">INSTALLATION</h3>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;">npm install dygram</pre>
+                </div>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">PARSING</h3>
+                <p>Parse DyGram source code into an Abstract Syntax Tree (AST):</p>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.95rem;">import { createMachineServices } from 'dygram';
+import { EmptyFileSystem } from 'langium';
+
+const services = createMachineServices(EmptyFileSystem);
+const parser = services.Machine.parser.LangiumParser;
+
+const code = `machine "Example"
+  state a;
+  state b;
+  a -> b;`;
+
+const result = parser.parse(code);
+
+if (result.lexerErrors.length === 0 &&
+    result.parserErrors.length === 0) {
+  console.log('Parsed successfully!');
+  console.log(result.value);
+}</pre>
+                </div>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">EXECUTION</h3>
+                <p>Execute DyGram programs and access results:</p>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.95rem;">import { execute } from 'dygram/cli';
+
+const code = `machine "Task"
+  Input query { text: "Hello" };
+  Task process {
+    prompt: "Process {{ query.text }}"
+  };
+  Result output { value: "TBD" };
+
+  query -> process -> output;`;
+
+const result = await execute(code);
+console.log(result.output);</pre>
+                </div>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">VALIDATION</h3>
+                <p>Validate DyGram code and get diagnostic messages:</p>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.95rem;">import { createMachineServices } from 'dygram';
+import { EmptyFileSystem } from 'langium';
+
+const services = createMachineServices(EmptyFileSystem);
+const validator = services.Machine.validation.DocumentValidator;
+
+// Parse and validate
+const document = await services.shared.workspace
+  .LangiumDocuments.getOrCreateDocument(uri, code);
+
+const diagnostics = await validator.validateDocument(document);
+
+diagnostics.forEach(diag => {
+  console.log(`${diag.severity}: ${diag.message}`);
+});</pre>
+                </div>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">DIAGRAM GENERATION</h3>
+                <p>Generate Mermaid diagrams from DyGram code:</p>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.95rem;">import { generateMermaid } from 'dygram/cli';
+
+const code = `machine "Flow"
+  state start;
+  state end;
+  start -> end;`;
+
+const mermaid = generateMermaid(code);
+console.log(mermaid);
+
+// Output:
+// graph TD
+//   start --> end</pre>
+                </div>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">LANGUAGE SERVER</h3>
+                <p>Start a language server for editor integration:</p>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.95rem;">import { startLanguageServer } from 'dygram/language-server';
+import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
+
+const connection = createConnection(ProposedFeatures.all);
+
+startLanguageServer(connection);</pre>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">CLI Commands</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    DyGram provides a command-line interface:
+                </p>
+
+                <div class="feature-grid">
+                    <div class="feature">
+                        <h3 class="feature-title">EXECUTE</h3>
+                        <div class="code-block">
+                            <pre style="background: var(--code-bg); color: var(--light); padding: 1rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">npx dygram file.mach</pre>
+                        </div>
+                        <p style="margin-top: 0.5rem;">Execute a DyGram file</p>
+                    </div>
+
+                    <div class="feature">
+                        <h3 class="feature-title">VALIDATE</h3>
+                        <div class="code-block">
+                            <pre style="background: var(--code-bg); color: var(--light); padding: 1rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">npx dygram validate file.mach</pre>
+                        </div>
+                        <p style="margin-top: 0.5rem;">Check syntax and semantics</p>
+                    </div>
+
+                    <div class="feature">
+                        <h3 class="feature-title">EXPORT</h3>
+                        <div class="code-block">
+                            <pre style="background: var(--code-bg); color: var(--light); padding: 1rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">npx dygram export --format mermaid file.mach</pre>
+                        </div>
+                        <p style="margin-top: 0.5rem;">Generate diagrams and documentation</p>
+                    </div>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">TypeScript Support</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 1rem;">
+                    DyGram is written in TypeScript and provides full type definitions for all APIs.
+                </p>
+                <p style="font-size: 1.2rem;">
+                    See the <a href="https://github.com/christopherdebeer/machine" style="color: var(--accent); text-decoration: none;">GitHub repository</a> for detailed type information and source code.
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-links">
+                    <h3>DOCUMENTATION</h3>
+                    <ul>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>RESOURCES</h3>
+                    <ul>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>COMMUNITY</h3>
+                    <ul>
+                        <li><a href="#">Discord</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                &copy; 2025 DyGram. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blog | DyGram</title>
+    <link rel="stylesheet" href="static/styles/main.css">
+</head>
+<body>
+    <header style="height: auto; padding: 4rem 0;">
+        <div class="container">
+            <a href="index.html" style="color: var(--primary); text-decoration: none; font-size: 1.2rem;">← Back to Home</a>
+            <div class="title-block" style="margin-top: 2rem;">
+                Blog<span class="accent">.</span>
+            </div>
+        </div>
+    </header>
+
+    <section>
+        <div class="container">
+            <h2 class="section-title">Latest Updates</h2>
+            <p style="font-size: 1.2rem; margin-bottom: 3rem;">
+                News, tutorials, and insights about DyGram development.
+            </p>
+
+            <div class="feature-grid">
+                <div class="feature">
+                    <div style="color: var(--accent); font-size: 0.9rem; margin-bottom: 0.5rem;">2025-10-06</div>
+                    <h3 class="feature-title">WELCOME TO DYGRAM</h3>
+                    <p style="margin-bottom: 1rem;">
+                        Introducing DyGram: a lean, executable DSL for rapid prototyping that evolves from unstructured sketches to complete systems.
+                    </p>
+                    <p style="font-size: 0.95rem;">
+                        DyGram bridges the gap between conceptual thinking and structured implementation. Start with broad, immediately executable concepts and refine through iteration and feedback.
+                    </p>
+                </div>
+
+                <div class="feature">
+                    <div style="color: var(--accent); font-size: 0.9rem; margin-bottom: 0.5rem;">2025-10-06</div>
+                    <h3 class="feature-title">MOBILE-FIRST PLAYGROUND</h3>
+                    <p style="margin-bottom: 1rem;">
+                        We've launched a new CodeMirror 6-based playground optimized for mobile devices with native touch support.
+                    </p>
+                    <p style="font-size: 0.95rem;">
+                        While Monaco Editor excels on desktop, CodeMirror 6 provides a superior mobile experience with native selection, better performance, and touch-optimized UI.
+                    </p>
+                </div>
+
+                <div class="feature">
+                    <div style="color: var(--accent); font-size: 0.9rem; margin-bottom: 0.5rem;">2025-10-06</div>
+                    <h3 class="feature-title">LANGUAGE SERVER SUPPORT</h3>
+                    <p style="margin-bottom: 1rem;">
+                        Full LSP integration powered by Langium brings IntelliSense, validation, and more to VS Code and other editors.
+                    </p>
+                    <p style="font-size: 0.95rem;">
+                        The language server provides real-time diagnostics, code completion, go-to-definition, and all the features you'd expect from a modern development environment.
+                    </p>
+                </div>
+
+                <div class="feature">
+                    <div style="color: var(--accent); font-size: 0.9rem; margin-bottom: 0.5rem;">COMING SOON</div>
+                    <h3 class="feature-title">GENERATIVE AI INTEGRATION</h3>
+                    <p style="margin-bottom: 1rem;">
+                        We're working on deeper integration with AI models for Task nodes, enabling seamless prompt-based workflows.
+                    </p>
+                    <p style="font-size: 0.95rem;">
+                        Define AI tasks with natural language prompts and let DyGram orchestrate the execution, combining structured data with generative capabilities.
+                    </p>
+                </div>
+
+                <div class="feature">
+                    <div style="color: var(--accent); font-size: 0.9rem; margin-bottom: 0.5rem;">COMING SOON</div>
+                    <h3 class="feature-title">VISUAL EDITOR</h3>
+                    <p style="margin-bottom: 1rem;">
+                        A graphical interface for building DyGram diagrams with drag-and-drop nodes and connections.
+                    </p>
+                    <p style="font-size: 0.95rem;">
+                        Seamlessly switch between code and visual editing modes, with real-time synchronization between both views.
+                    </p>
+                </div>
+
+                <div class="feature">
+                    <div style="color: var(--accent); font-size: 0.9rem; margin-bottom: 0.5rem;">COMING SOON</div>
+                    <h3 class="feature-title">PLUGIN ECOSYSTEM</h3>
+                    <p style="margin-bottom: 1rem;">
+                        Extensible plugin system for custom entity types, validators, and execution engines.
+                    </p>
+                    <p style="font-size: 0.95rem;">
+                        Create domain-specific extensions that add new capabilities to DyGram while maintaining compatibility with the core language.
+                    </p>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem; padding: 3rem; background: var(--secondary); color: white; border-radius: 8px;">
+                <h2 class="section-title" style="font-size: 2rem; margin-bottom: 1rem;">Stay Updated</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    Follow development progress and join the conversation:
+                </p>
+                <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
+                    <a href="https://github.com/christopherdebeer/machine" target="_blank" class="btn" style="background: white; color: var(--primary);">GITHUB →</a>
+                    <a href="#" class="btn btn-secondary" style="background: var(--primary); color: white;">DISCORD →</a>
+                    <a href="#" class="btn btn-secondary" style="background: var(--primary); color: white;">TWITTER →</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-links">
+                    <h3>DOCUMENTATION</h3>
+                    <ul>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>RESOURCES</h3>
+                    <ul>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>COMMUNITY</h3>
+                    <ul>
+                        <li><a href="#">Discord</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                &copy; 2025 DyGram. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/events.html
+++ b/events.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Events | DyGram</title>
+    <link rel="stylesheet" href="static/styles/main.css">
+</head>
+<body>
+    <header style="height: auto; padding: 4rem 0;">
+        <div class="container">
+            <a href="index.html" style="color: var(--primary); text-decoration: none; font-size: 1.2rem;">← Back to Home</a>
+            <div class="title-block" style="margin-top: 2rem;">
+                Events<span class="accent">.</span>
+            </div>
+        </div>
+    </header>
+
+    <section>
+        <div class="container">
+            <h2 class="section-title">Community Events</h2>
+            <p style="font-size: 1.2rem; margin-bottom: 3rem;">
+                Join workshops, talks, and community gatherings focused on DyGram.
+            </p>
+
+            <div style="padding: 4rem 2rem; background: var(--light); border: 3px solid var(--primary); text-align: center; margin-bottom: 4rem;">
+                <h3 class="section-title" style="font-size: 2.5rem; margin-bottom: 1rem;">Coming Soon</h3>
+                <p style="font-size: 1.2rem; max-width: 600px; margin: 0 auto;">
+                    We're planning community events, workshops, and meetups. Check back soon for announcements!
+                </p>
+            </div>
+
+            <div class="feature-grid">
+                <div class="feature">
+                    <h3 class="feature-title">WORKSHOPS</h3>
+                    <p>
+                        Interactive sessions covering DyGram fundamentals, advanced patterns, and real-world applications.
+                    </p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Getting Started with DyGram</li>
+                        <li>Building AI-Powered Workflows</li>
+                        <li>Domain Modeling Best Practices</li>
+                        <li>VS Code Extension Development</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">TALKS & PRESENTATIONS</h3>
+                    <p>
+                        Deep dives into DyGram architecture, language design decisions, and case studies from the community.
+                    </p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>The Evolution of DyGram</li>
+                        <li>LSP Integration with Langium</li>
+                        <li>Mobile-First Code Editors</li>
+                        <li>From Concept to System</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">COMMUNITY CALLS</h3>
+                    <p>
+                        Regular online meetings to discuss features, share projects, and collaborate on improvements.
+                    </p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Monthly community sync</li>
+                        <li>Feature request discussions</li>
+                        <li>Show and tell sessions</li>
+                        <li>Q&A with maintainers</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">HACKATHONS</h3>
+                    <p>
+                        Build creative projects with DyGram, compete for prizes, and connect with other developers.
+                    </p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Domain-specific challenges</li>
+                        <li>Integration competitions</li>
+                        <li>Plugin development contests</li>
+                        <li>Community project sprints</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">ONLINE MEETUPS</h3>
+                    <p>
+                        Virtual gatherings for casual conversation, networking, and knowledge sharing.
+                    </p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Regional user groups</li>
+                        <li>Topic-focused discussions</li>
+                        <li>Pair programming sessions</li>
+                        <li>Office hours</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">CONFERENCES</h3>
+                    <p>
+                        DyGram presence at major tech conferences and language design events.
+                    </p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Language design summits</li>
+                        <li>Developer conferences</li>
+                        <li>Academic workshops</li>
+                        <li>Industry meetups</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem; padding: 3rem; background: var(--primary); color: white; border-radius: 8px;">
+                <h2 class="section-title" style="font-size: 2rem; margin-bottom: 1rem; color: white;">Get Notified</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    Want to be the first to know about upcoming events?
+                </p>
+                <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
+                    <a href="https://github.com/christopherdebeer/machine" target="_blank" class="btn" style="background: white; color: var(--primary);">WATCH ON GITHUB →</a>
+                    <a href="#" class="btn btn-secondary" style="background: var(--accent); color: white;">JOIN DISCORD →</a>
+                </div>
+                <p style="font-size: 1rem; margin-top: 2rem; opacity: 0.9;">
+                    Follow our GitHub repository and join Discord to stay updated on event announcements and community activities.
+                </p>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Host an Event</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 1rem;">
+                    Interested in organizing a DyGram event in your area or online?
+                </p>
+                <p style="font-size: 1.1rem;">
+                    We'd love to help! Reach out via <a href="https://github.com/christopherdebeer/machine/issues" target="_blank" style="color: var(--accent); text-decoration: none; font-weight: 600;">GitHub Issues</a> or Discord to discuss event ideas, get promotional support, and connect with other organizers.
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-links">
+                    <h3>DOCUMENTATION</h3>
+                    <ul>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>RESOURCES</h3>
+                    <ul>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>COMMUNITY</h3>
+                    <ul>
+                        <li><a href="#">Discord</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                &copy; 2025 DyGram. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/examples.html
+++ b/examples.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Examples | DyGram</title>
+    <link rel="stylesheet" href="static/styles/main.css">
+</head>
+<body>
+    <header style="height: auto; padding: 4rem 0;">
+        <div class="container">
+            <a href="index.html" style="color: var(--primary); text-decoration: none; font-size: 1.2rem;">← Back to Home</a>
+            <div class="title-block" style="margin-top: 2rem;">
+                Examples<span class="accent">.</span>
+            </div>
+        </div>
+    </header>
+
+    <section>
+        <div class="container">
+            <h2 class="section-title">Learn by Example</h2>
+            <p style="font-size: 1.2rem; margin-bottom: 3rem;">
+                Explore real-world DyGram patterns and use cases.
+            </p>
+
+            <div class="feature-grid">
+                <div class="feature">
+                    <h3 class="feature-title">01. KNOWLEDGE MANAGEMENT</h3>
+                    <p>Track ideas from conception to implementation:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">machine "Knowledge System"
+
+Concept idea "Neural Interface" {
+    creator: "Research Team";
+    priority&lt;Integer&gt;: 8;
+    domain: "Neuroscience";
+};
+
+Implementation impl {
+    status: "In Progress";
+    owner: "Engineering";
+};
+
+Resource paper {
+    url: "https://example.com/paper";
+};
+
+idea -inspires-> impl;
+idea -documented_in-> paper;</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">02. PROJECT MANAGEMENT</h3>
+                    <p>Model teams, features, and tasks:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">machine "Project Tracker"
+
+Team team {
+    lead: "Jane Smith";
+    members: ["Alice", "Bob"];
+};
+
+Feature dashboard {
+    priority&lt;Integer&gt;: 8;
+    status: "In Progress";
+};
+
+Task design {
+    assignee: "Alice";
+    status: "Completed";
+};
+
+team -owns-> dashboard;
+dashboard -includes-> design;</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">03. SUPPLY CHAIN</h3>
+                    <p>Model complex supply chain relationships:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">machine "Supply Chain"
+
+Entity supplier {
+    location: "Shanghai";
+    reliability&lt;Float&gt;: 0.92;
+};
+
+Entity component {
+    sku: "CP-X5000";
+    stock&lt;Integer&gt;: 250;
+};
+
+Process ordering {
+    trigger: "Low stock";
+    owner: "Procurement";
+};
+
+supplier -provides-> component;
+component -tracked_in-> ordering;</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">04. AI WORKFLOW</h3>
+                    <p>Build generative AI pipelines:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">machine "Content Generator"
+
+Input topic {
+    subject&lt;string&gt;: "AI Safety";
+};
+
+Task research {
+    prompt: "Research {{ topic.subject }}";
+};
+
+Task write {
+    prompt: "Write article on research";
+};
+
+Result article {
+    content: "TBD";
+};
+
+topic -> research -> write -> article;</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">05. DATA PIPELINE</h3>
+                    <p>Simple data flow visualization:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">machine "Data Pipeline"
+
+Concept source "API";
+Concept processor "Transform";
+Concept destination "Database";
+
+source -> processor -> destination;</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">06. AUTHENTICATION FLOW</h3>
+                    <p>Security system modeling:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">machine "Auth System"
+
+Concept problem "User Auth" {
+    domain: "Security";
+    priority&lt;Integer&gt;: 9;
+};
+
+Concept solution "JWT Auth" {
+    status: "Testing";
+    approach: "Token-based";
+};
+
+Resource docs {
+    url: "repo.com/auth-flow.pdf";
+};
+
+problem -solved_by-> solution;
+solution -documented_in-> docs;</pre>
+                    </div>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem; text-align: center;">
+                <h2 class="section-title">Try Them Yourself</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    Copy any example and run it in the playground:
+                </p>
+                <a href="playground-mobile.html" class="btn">OPEN PLAYGROUND →</a>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-links">
+                    <h3>DOCUMENTATION</h3>
+                    <ul>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>RESOURCES</h3>
+                    <ul>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>COMMUNITY</h3>
+                    <ul>
+                        <li><a href="#">Discord</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                &copy; 2025 DyGram. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/grammar-reference.html
+++ b/grammar-reference.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Grammar Reference | DyGram</title>
+    <link rel="stylesheet" href="static/styles/main.css">
+</head>
+<body>
+    <header style="height: auto; padding: 4rem 0;">
+        <div class="container">
+            <a href="index.html" style="color: var(--primary); text-decoration: none; font-size: 1.2rem;">← Back to Home</a>
+            <div class="title-block" style="margin-top: 2rem;">
+                Grammar Reference<span class="accent">.</span>
+            </div>
+        </div>
+    </header>
+
+    <section>
+        <div class="container">
+            <h2 class="section-title">Language Syntax</h2>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">BASIC STRUCTURE</h3>
+                <p>Every DyGram program starts with a machine declaration:</p>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;">machine "My System"
+
+// Define states
+state start;
+state process;
+state end;
+
+// Define connections
+start -> process -> end;</pre>
+                </div>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">TYPED CONCEPTS</h3>
+                <p>Add structure and metadata to your concepts:</p>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;">Concept task "User Story" {
+    description&lt;string&gt;: "Implement feature";
+    priority&lt;Integer&gt;: 8;
+    tags: ["backend", "api"];
+};
+
+Concept implementation {
+    status: "In Progress";
+    owner: "Engineering";
+};
+
+task -drives-> implementation;</pre>
+                </div>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">GENERATIVE TASKS</h3>
+                <p>Integrate AI-powered tasks with prompt templates:</p>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;">Input query {
+    text&lt;string&gt;: "Analyze sentiment";
+};
+
+Task analyze {
+    prompt: "Given {{ query.text }}, provide analysis";
+};
+
+Result output {
+    sentiment: "TBD";
+};
+
+query -> analyze -> output;</pre>
+                </div>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">ENTITY TYPES</h3>
+                <p>DyGram supports multiple entity types:</p>
+                <ul style="margin-top: 1rem; font-size: 1.1rem; line-height: 1.8;">
+                    <li><strong>Concept</strong> - Abstract ideas and domain concepts</li>
+                    <li><strong>Entity</strong> - Concrete domain objects</li>
+                    <li><strong>Task</strong> - Generative AI tasks with prompts</li>
+                    <li><strong>Input</strong> - System inputs and parameters</li>
+                    <li><strong>Result</strong> - Output values and results</li>
+                    <li><strong>Resource</strong> - External resources and references</li>
+                    <li><strong>Process</strong> - Business processes and workflows</li>
+                    <li><strong>Implementation</strong> - Technical implementations</li>
+                    <li><strong>Feature</strong> - Product features</li>
+                    <li><strong>Team</strong> - Teams and organizational units</li>
+                </ul>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">TYPE ANNOTATIONS</h3>
+                <p>Supported type annotations:</p>
+                <ul style="margin-top: 1rem; font-size: 1.1rem; line-height: 1.8;">
+                    <li><strong>&lt;string&gt;</strong> - Text values</li>
+                    <li><strong>&lt;Integer&gt;</strong> - Whole numbers</li>
+                    <li><strong>&lt;Float&gt;</strong> - Decimal numbers</li>
+                    <li><strong>&lt;Date&gt;</strong> - Date values</li>
+                    <li><strong>&lt;UUID&gt;</strong> - Unique identifiers</li>
+                    <li><strong>&lt;Currency&gt;</strong> - Monetary values</li>
+                    <li><strong>&lt;SemanticVersion&gt;</strong> - Version numbers</li>
+                    <li><strong>&lt;AccessLevel&gt;</strong> - Access control levels</li>
+                </ul>
+            </div>
+
+            <div class="feature" style="margin-bottom: 3rem;">
+                <h3 class="feature-title">RELATIONSHIPS</h3>
+                <p>Connect entities with labeled relationships:</p>
+                <div class="code-block" style="margin-top: 1rem;">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;">// Simple connection
+a -> b;
+
+// Labeled relationship
+a -drives-> b;
+
+// Relationship with metadata
+a -addresses, confidence: 0.9-> b;</pre>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-links">
+                    <h3>DOCUMENTATION</h3>
+                    <ul>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>RESOURCES</h3>
+                    <ul>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>COMMUNITY</h3>
+                    <ul>
+                        <li><a href="#">Discord</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                &copy; 2025 DyGram. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -346,19 +346,19 @@ ordering -involves-> supplier;</div>
                 <div class="footer-links">
                     <h3>DOCUMENTATION</h3>
                     <ul>
-                        <li><a href="#">Quick Start</a></li>
-                        <li><a href="#">Grammar Reference</a></li>
-                        <li><a href="#">Examples</a></li>
-                        <li><a href="#">Integration</a></li>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
                     </ul>
                 </div>
                 <div class="footer-links">
                     <h3>RESOURCES</h3>
                     <ul>
-                        <li><a href="#">GitHub</a></li>
-                        <li><a href="#">VS Code Extension</a></li>
-                        <li><a href="#">API</a></li>
-                        <li><a href="#">Libraries</a></li>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
                     </ul>
                 </div>
                 <div class="footer-links">
@@ -366,8 +366,8 @@ ordering -involves-> supplier;</div>
                     <ul>
                         <li><a href="#">Discord</a></li>
                         <li><a href="#">Twitter</a></li>
-                        <li><a href="#">Blog</a></li>
-                        <li><a href="#">Events</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
                     </ul>
                 </div>
             </div>

--- a/integration.html
+++ b/integration.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Integration | DyGram</title>
+    <link rel="stylesheet" href="static/styles/main.css">
+</head>
+<body>
+    <header style="height: auto; padding: 4rem 0;">
+        <div class="container">
+            <a href="index.html" style="color: var(--primary); text-decoration: none; font-size: 1.2rem;">← Back to Home</a>
+            <div class="title-block" style="margin-top: 2rem;">
+                Integration<span class="accent">.</span>
+            </div>
+        </div>
+    </header>
+
+    <section>
+        <div class="container">
+            <h2 class="section-title">Integrate DyGram</h2>
+            <p style="font-size: 1.2rem; margin-bottom: 3rem;">
+                Embed DyGram into your development workflow and toolchain.
+            </p>
+
+            <div class="feature-grid">
+                <div class="feature">
+                    <h3 class="feature-title">VS CODE EXTENSION</h3>
+                    <p>Get full language support in Visual Studio Code:</p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Syntax highlighting</li>
+                        <li>Code completion</li>
+                        <li>Real-time validation</li>
+                        <li>Mermaid diagram preview</li>
+                    </ul>
+                    <a href="vscode-extension.html" class="btn" style="margin-top: 1rem; font-size: 1rem; padding: 0.75rem 1.5rem;">LEARN MORE →</a>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">LANGUAGE SERVER</h3>
+                    <p>DyGram includes a full LSP implementation powered by Langium:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">import { startLanguageServer } from 'dygram';
+
+startLanguageServer({
+  port: 3000
+});</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">PROGRAMMATIC API</h3>
+                    <p>Use DyGram as a library in your Node.js applications:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">import { parse, execute } from 'dygram';
+
+const code = `machine "Test"
+  state a;
+  state b;
+  a -> b;`;
+
+const ast = parse(code);
+const result = execute(ast);</pre>
+                    </div>
+                    <a href="api.html" class="btn" style="margin-top: 1rem; font-size: 1rem; padding: 0.75rem 1.5rem;">API REFERENCE →</a>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">WEB EMBEDDING</h3>
+                    <p>Embed the DyGram editor in your web applications:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;">&lt;script src="dygram-web.js"&gt;&lt;/script&gt;
+&lt;div id="editor"&gt;&lt;/div&gt;
+&lt;script&gt;
+  DyGram.createEditor({
+    container: '#editor',
+    value: 'machine "Hello"'
+  });
+&lt;/script&gt;</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">CI/CD INTEGRATION</h3>
+                    <p>Run DyGram in your continuous integration pipelines:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;"># GitHub Actions example
+- name: Validate DyGram files
+  run: |
+    npm install -g dygram
+    dygram validate **/*.mach</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">EXPORT FORMATS</h3>
+                    <p>Generate diagrams and documentation:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 0.9rem;"># Generate Mermaid diagram
+dygram export --format mermaid file.mach
+
+# Export to JSON
+dygram export --format json file.mach</pre>
+                    </div>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Build Tools</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    DyGram integrates with modern build tools:
+                </p>
+                <div class="feature-grid">
+                    <div class="feature">
+                        <h3 class="feature-title">VITE</h3>
+                        <p>Included Vite configuration for fast development and optimized production builds.</p>
+                    </div>
+                    <div class="feature">
+                        <h3 class="feature-title">ESBUILD</h3>
+                        <p>Lightning-fast bundling for CLI and library distributions.</p>
+                    </div>
+                    <div class="feature">
+                        <h3 class="feature-title">LANGIUM</h3>
+                        <p>Built on Langium for robust LSP support and language tooling.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-links">
+                    <h3>DOCUMENTATION</h3>
+                    <ul>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>RESOURCES</h3>
+                    <ul>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>COMMUNITY</h3>
+                    <ul>
+                        <li><a href="#">Discord</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                &copy; 2025 DyGram. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/libraries.html
+++ b/libraries.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Libraries | DyGram</title>
+    <link rel="stylesheet" href="static/styles/main.css">
+</head>
+<body>
+    <header style="height: auto; padding: 4rem 0;">
+        <div class="container">
+            <a href="index.html" style="color: var(--primary); text-decoration: none; font-size: 1.2rem;">← Back to Home</a>
+            <div class="title-block" style="margin-top: 2rem;">
+                Libraries<span class="accent">.</span>
+            </div>
+        </div>
+    </header>
+
+    <section>
+        <div class="container">
+            <h2 class="section-title">Built With</h2>
+            <p style="font-size: 1.2rem; margin-bottom: 3rem;">
+                DyGram is powered by best-in-class open source libraries.
+            </p>
+
+            <div class="feature-grid">
+                <div class="feature">
+                    <h3 class="feature-title">LANGIUM</h3>
+                    <p>Language engineering framework that powers the DSL, parser, and Language Server Protocol implementation.</p>
+                    <a href="https://langium.org/" target="_blank" style="color: var(--accent); text-decoration: none; font-weight: 600; margin-top: 1rem; display: inline-block;">langium.org →</a>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">MONACO EDITOR</h3>
+                    <p>The code editor that powers VS Code, providing rich IntelliSense and editing features in the desktop playground.</p>
+                    <a href="https://microsoft.github.io/monaco-editor/" target="_blank" style="color: var(--accent); text-decoration: none; font-weight: 600; margin-top: 1rem; display: inline-block;">monaco-editor →</a>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">CODEMIRROR 6</h3>
+                    <p>Lightweight, extensible code editor optimized for mobile devices, powering the mobile playground experience.</p>
+                    <a href="https://codemirror.net/" target="_blank" style="color: var(--accent); text-decoration: none; font-weight: 600; margin-top: 1rem; display: inline-block;">codemirror.net →</a>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">VITE</h3>
+                    <p>Next-generation frontend build tool that provides lightning-fast development server and optimized production builds.</p>
+                    <a href="https://vitejs.dev/" target="_blank" style="color: var(--accent); text-decoration: none; font-weight: 600; margin-top: 1rem; display: inline-block;">vitejs.dev →</a>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">MERMAID</h3>
+                    <p>Markdown-inspired diagram generation that creates beautiful visualizations from DyGram state machines.</p>
+                    <a href="https://mermaid.js.org/" target="_blank" style="color: var(--accent); text-decoration: none; font-weight: 600; margin-top: 1rem; display: inline-block;">mermaid.js.org →</a>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">ESBUILD</h3>
+                    <p>Extremely fast JavaScript bundler used for CLI and library distribution builds.</p>
+                    <a href="https://esbuild.github.io/" target="_blank" style="color: var(--accent); text-decoration: none; font-weight: 600; margin-top: 1rem; display: inline-block;">esbuild.github.io →</a>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Development Dependencies</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    Additional tools that make DyGram development productive:
+                </p>
+
+                <div class="feature-grid">
+                    <div class="feature">
+                        <h3 class="feature-title">TYPESCRIPT</h3>
+                        <p>Type-safe development with full IntelliSense and compile-time error checking.</p>
+                    </div>
+
+                    <div class="feature">
+                        <h3 class="feature-title">VITEST</h3>
+                        <p>Blazing fast unit testing framework with native TypeScript support.</p>
+                    </div>
+
+                    <div class="feature">
+                        <h3 class="feature-title">ESLINT</h3>
+                        <p>Code quality and style enforcement to maintain consistent, clean code.</p>
+                    </div>
+
+                    <div class="feature">
+                        <h3 class="feature-title">CHEVROTAIN</h3>
+                        <p>Parser building toolkit used by Langium for robust syntax analysis.</p>
+                    </div>
+
+                    <div class="feature">
+                        <h3 class="feature-title">VSCODE API</h3>
+                        <p>Extension API for building first-class VS Code integration.</p>
+                    </div>
+
+                    <div class="feature">
+                        <h3 class="feature-title">NODE.JS</h3>
+                        <p>Runtime environment for CLI tools and language server execution.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Why These Libraries?</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    Each library was chosen for its excellence in a specific domain:
+                </p>
+
+                <div class="feature">
+                    <ul style="font-size: 1.1rem; line-height: 2;">
+                        <li><strong>Langium</strong> - Purpose-built for language engineering with LSP built-in</li>
+                        <li><strong>Monaco</strong> - Industry-leading editor with proven reliability</li>
+                        <li><strong>CodeMirror</strong> - Best mobile editing experience available</li>
+                        <li><strong>Vite</strong> - Fastest development experience with modern ES modules</li>
+                        <li><strong>Mermaid</strong> - Beautiful diagrams without heavy dependencies</li>
+                        <li><strong>Esbuild</strong> - Unmatched bundling speed for distribution</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Contributing</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 1rem;">
+                    DyGram is open source. We welcome contributions that improve the language, tooling, or documentation.
+                </p>
+                <a href="https://github.com/christopherdebeer/machine" target="_blank" class="btn">VIEW ON GITHUB →</a>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-links">
+                    <h3>DOCUMENTATION</h3>
+                    <ul>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>RESOURCES</h3>
+                    <ul>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>COMMUNITY</h3>
+                    <ul>
+                        <li><a href="#">Discord</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                &copy; 2025 DyGram. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/quick-start.html
+++ b/quick-start.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quick Start | DyGram</title>
+    <link rel="stylesheet" href="static/styles/main.css">
+</head>
+<body>
+    <header style="height: auto; padding: 4rem 0;">
+        <div class="container">
+            <a href="index.html" style="color: var(--primary); text-decoration: none; font-size: 1.2rem;">← Back to Home</a>
+            <div class="title-block" style="margin-top: 2rem;">
+                Quick Start<span class="accent">.</span>
+            </div>
+        </div>
+    </header>
+
+    <section>
+        <div class="container">
+            <h2 class="section-title">Getting Started</h2>
+
+            <div class="feature-grid">
+                <div class="feature">
+                    <h3 class="feature-title">01. INSTALLATION</h3>
+                    <p>Install DyGram via npm:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;">npm install</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">02. DEVELOPMENT</h3>
+                    <p>Start the development server:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;">npm run dev</pre>
+                    </div>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">03. CLI USAGE</h3>
+                    <p>Execute .mach files directly:</p>
+                    <div class="code-block" style="margin-top: 1rem;">
+                        <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;">npx dygram your-file.mach</pre>
+                    </div>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Your First Machine</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    Create a file called <code>hello.mach</code> with the following content:
+                </p>
+                <div class="code-block">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px; font-size: 1rem;">machine "Hello World"
+
+state start;
+state process;
+state end;
+
+start -> process -> end;</pre>
+                </div>
+
+                <p style="font-size: 1.2rem; margin-top: 2rem;">
+                    Run it:
+                </p>
+                <div class="code-block">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;">npx dygram hello.mach</pre>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Playground</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    Try DyGram instantly in your browser without installation:
+                </p>
+                <a href="playground-mobile.html" class="btn">MOBILE PLAYGROUND →</a>
+                <a href="playground.html" class="btn btn-secondary" style="margin-left: 12px; background: #3e3e42;">MONACO PLAYGROUND →</a>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-links">
+                    <h3>DOCUMENTATION</h3>
+                    <ul>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>RESOURCES</h3>
+                    <ul>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>COMMUNITY</h3>
+                    <ul>
+                        <li><a href="#">Discord</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                &copy; 2025 DyGram. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/vscode-extension.html
+++ b/vscode-extension.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VS Code Extension | DyGram</title>
+    <link rel="stylesheet" href="static/styles/main.css">
+</head>
+<body>
+    <header style="height: auto; padding: 4rem 0;">
+        <div class="container">
+            <a href="index.html" style="color: var(--primary); text-decoration: none; font-size: 1.2rem;">← Back to Home</a>
+            <div class="title-block" style="margin-top: 2rem;">
+                VS Code Extension<span class="accent">.</span>
+            </div>
+        </div>
+    </header>
+
+    <section>
+        <div class="container">
+            <h2 class="section-title">Editor Integration</h2>
+            <p style="font-size: 1.2rem; margin-bottom: 3rem;">
+                Full DyGram language support in Visual Studio Code.
+            </p>
+
+            <div class="feature-grid">
+                <div class="feature">
+                    <h3 class="feature-title">SYNTAX HIGHLIGHTING</h3>
+                    <p>Beautiful, semantic syntax highlighting for .mach files with support for:</p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Keywords and entity types</li>
+                        <li>Relationships and connections</li>
+                        <li>Type annotations</li>
+                        <li>String interpolation</li>
+                        <li>Comments</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">INTELLISENSE</h3>
+                    <p>Smart code completion powered by Langium LSP:</p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Entity type suggestions</li>
+                        <li>Attribute completions</li>
+                        <li>Relationship labels</li>
+                        <li>Type annotations</li>
+                        <li>Context-aware suggestions</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">REAL-TIME VALIDATION</h3>
+                    <p>Instant feedback on syntax and semantic errors:</p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Syntax error detection</li>
+                        <li>Type checking</li>
+                        <li>Undefined reference warnings</li>
+                        <li>Quick fixes</li>
+                        <li>Inline diagnostics</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">DIAGRAM PREVIEW</h3>
+                    <p>Visualize your DyGram models as Mermaid diagrams directly in the editor:</p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Live diagram generation</li>
+                        <li>Side-by-side view</li>
+                        <li>Auto-refresh on save</li>
+                        <li>Export to PNG/SVG</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">CODE NAVIGATION</h3>
+                    <p>Navigate large DyGram files with ease:</p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Go to definition</li>
+                        <li>Find all references</li>
+                        <li>Symbol outline</li>
+                        <li>Breadcrumb navigation</li>
+                    </ul>
+                </div>
+
+                <div class="feature">
+                    <h3 class="feature-title">FORMATTING</h3>
+                    <p>Keep your code clean and consistent:</p>
+                    <ul style="margin-top: 1rem; line-height: 1.8;">
+                        <li>Auto-formatting on save</li>
+                        <li>Configurable indentation</li>
+                        <li>Code folding</li>
+                        <li>Comment toggling</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Installation</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    The extension is built into the project. To develop with it:
+                </p>
+                <div class="code-block">
+                    <pre style="background: var(--code-bg); color: var(--light); padding: 1.5rem; overflow-x: auto; border-radius: 4px;"># Clone the repository
+git clone https://github.com/christopherdebeer/machine.git
+
+# Install dependencies
+npm install
+
+# Build the extension
+npm run build
+
+# Open in VS Code
+code .</pre>
+                </div>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Usage</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 1rem;">
+                    Create a new file with the <code>.mach</code> extension and start typing. The extension will automatically activate and provide language support.
+                </p>
+                <p style="font-size: 1.2rem;">
+                    Press <strong>F5</strong> to launch a development instance of VS Code with the extension loaded.
+                </p>
+            </div>
+
+            <div style="margin-top: 4rem;">
+                <h2 class="section-title" style="font-size: 2rem;">Technology</h2>
+                <p style="font-size: 1.2rem; margin-bottom: 2rem;">
+                    Built with modern language server technology:
+                </p>
+                <div class="feature-grid">
+                    <div class="feature">
+                        <h3 class="feature-title">LANGIUM</h3>
+                        <p>Powerful language engineering framework that provides the foundation for all language features.</p>
+                    </div>
+                    <div class="feature">
+                        <h3 class="feature-title">LSP</h3>
+                        <p>Language Server Protocol ensures consistent behavior across all editors that support LSP.</p>
+                    </div>
+                    <div class="feature">
+                        <h3 class="feature-title">MONACO</h3>
+                        <p>VS Code's editor component provides rich editing capabilities in the browser playground.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-grid">
+                <div class="footer-links">
+                    <h3>DOCUMENTATION</h3>
+                    <ul>
+                        <li><a href="quick-start.html">Quick Start</a></li>
+                        <li><a href="grammar-reference.html">Grammar Reference</a></li>
+                        <li><a href="examples.html">Examples</a></li>
+                        <li><a href="integration.html">Integration</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>RESOURCES</h3>
+                    <ul>
+                        <li><a href="https://github.com/christopherdebeer/machine" target="_blank">GitHub</a></li>
+                        <li><a href="vscode-extension.html">VS Code Extension</a></li>
+                        <li><a href="api.html">API</a></li>
+                        <li><a href="libraries.html">Libraries</a></li>
+                    </ul>
+                </div>
+                <div class="footer-links">
+                    <h3>COMMUNITY</h3>
+                    <ul>
+                        <li><a href="#">Discord</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="events.html">Events</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                &copy; 2025 DyGram. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
Closes #12

Added all missing documentation, resource, and community pages from the footer.

## Changes
- Created 9 new HTML pages with comprehensive content
- Updated footer links in index.html
- All pages maintain consistent styling with main site
- GitHub link now points to actual repository
- Social links left as placeholders as requested

🤖 Generated with [Claude Code](https://claude.ai/code)