### PR TITLE
feat: Add text wrapping to Mermaid diagrams

### DIFF
--- a/src/language/generator/generator.ts
+++ b/src/language/generator/generator.ts
@@ -213,6 +213,28 @@ interface TypeHierarchy {
     };
 }
 
+// Helper function to wrap text at word boundaries
+function wrapText(text: string, maxWidth: number = 60): string {
+    if (text.length <= maxWidth) return text;
+
+    const words = text.split(' ');
+    const lines: string[] = [];
+    let currentLine = '';
+
+    for (const word of words) {
+        const testLine = currentLine ? currentLine + ' ' + word : word;
+        if (testLine.length <= maxWidth) {
+            currentLine = testLine;
+        } else {
+            if (currentLine) lines.push(currentLine);
+            currentLine = word;
+        }
+    }
+    if (currentLine) lines.push(currentLine);
+
+    return lines.join('<br/>');
+}
+
 class MermaidGenerator extends BaseGenerator {
     protected fileExtension = 'md';
 
@@ -306,6 +328,7 @@ classDiagram-v2
                 let displayValue: any = desc?.value;
                 if (desc && typeof displayValue === 'string') {
                     displayValue = displayValue.replace(/^["']|["']$/g, ''); // Remove outer quotes
+                    displayValue = wrapText(displayValue, 60); // Apply text wrapping
                 }
                 const header = `class ${node.name}${desc ? `["${displayValue}"]` : ''}`;
 
@@ -318,6 +341,7 @@ classDiagram-v2
                         // Remove quotes from string values for display
                         if (typeof displayValue === 'string') {
                             displayValue = displayValue.replace(/^["']|["']$/g, '');
+                            displayValue = wrapText(displayValue, 60); // Apply text wrapping
                         }
                         return `+${a.name}${a.type ? ` : ${a.type}` : ''} = ${displayValue}`;
                     }).join('\n')
@@ -490,6 +514,7 @@ classDiagram-v2
                 let displayValue: any = desc?.value;
                 if (desc && typeof displayValue === 'string') {
                     displayValue = displayValue.replace(/^["']|["']$/g, ''); // Remove outer quotes
+                    displayValue = wrapText(displayValue, 60); // Apply text wrapping
                 }
                 const header = `class ${node.name}${desc ? `["${displayValue}"]` : ''}`;
 
@@ -502,6 +527,7 @@ classDiagram-v2
                         // Remove quotes from string values for display
                         if (typeof displayValue === 'string') {
                             displayValue = displayValue.replace(/^["']|["']$/g, '');
+                            displayValue = wrapText(displayValue, 60); // Apply text wrapping
                         }
                         return `+${a.name}${a.type ? ` : ${a.type}` : ''} = ${displayValue}`;
                     }).join('\n')

--- a/test-output/generative/code_generation_demo__advanced_context_management_.md
+++ b/test-output/generative/code_generation_demo__advanced_context_management_.md
@@ -96,27 +96,27 @@ classDiagram-v2
 }
 
 namespace Tasks {
-  class define_requirements["You are generating a simple JavaScript utility function. Create requirements for a function that validates email addresses. Use set_context_value to store the requirements in the 'requirements' context node with key 'spec' as a string describing: function name, parameters, return value, and test cases."] {
+  class define_requirements["You are generating a simple JavaScript utility function.<br/>Create requirements for a function that validates email<br/>addresses. Use set_context_value to store the requirements<br/>in the 'requirements' context node with key 'spec' as a<br/>string describing: function name, parameters, return value,<br/>and test cases."] {
     <<Task>>
     +meta = true
   }
 
-  class generate_code["Read the requirements from the 'requirements' context using get_context_value. Generate JavaScript code for the email validation function. Use set_context_value to store the generated code in the 'code' context node with key 'implementation' as a string containing the complete function implementation."] {
+  class generate_code["Read the requirements from the 'requirements' context using<br/>get_context_value. Generate JavaScript code for the email<br/>validation function. Use set_context_value to store the<br/>generated code in the 'code' context node with key<br/>'implementation' as a string containing the complete<br/>function implementation."] {
     <<Task>>
     +meta = true
   }
 
-  class generate_tests["Read the requirements from 'requirements' context and the implementation from 'code' context using get_context_value. Generate comprehensive test cases using a simple testing approach (no framework needed). Use set_context_value to store the test code in the 'tests' context node with key 'testCode' as a string."] {
+  class generate_tests["Read the requirements from 'requirements' context and the<br/>implementation from 'code' context using get_context_value.<br/>Generate comprehensive test cases using a simple testing<br/>approach (no framework needed). Use set_context_value to<br/>store the test code in the 'tests' context node with key<br/>'testCode' as a string."] {
     <<Task>>
     +meta = true
   }
 
-  class generate_documentation["Read the requirements, code implementation, and tests from their respective context nodes using get_context_value. Generate markdown documentation including: function signature, description, parameters, return value, examples, and how to run tests. Use set_context_value to store the documentation in the 'documentation' context node with key 'markdown' as a string."] {
+  class generate_documentation["Read the requirements, code implementation, and tests from<br/>their respective context nodes using get_context_value.<br/>Generate markdown documentation including: function<br/>signature, description, parameters, return value, examples,<br/>and how to run tests. Use set_context_value to store the<br/>documentation in the 'documentation' context node with key<br/>'markdown' as a string."] {
     <<Task>>
     +meta = true
   }
 
-  class validation["Review the generated code, tests, and documentation from their context nodes using get_context_value. Check for completeness and quality. If everything looks good, use set_context_value to store a validation summary in 'validation_result' context with key 'status' as 'passed' and 'summary' with any notes. Then use the transition tool to move to 'complete'."] {
+  class validation["Review the generated code, tests, and documentation from<br/>their context nodes using get_context_value. Check for<br/>completeness and quality. If everything looks good, use<br/>set_context_value to store a validation summary in<br/>'validation_result' context with key 'status' as 'passed'<br/>and 'summary' with any notes. Then use the transition tool<br/>to move to 'complete'."] {
     <<Task>>
     +meta = true
   }

--- a/test-output/generative/deep_attributes.md
+++ b/test-output/generative/deep_attributes.md
@@ -46,7 +46,7 @@ classDiagram-v2
     +config = opt1,opt2,opt3
 +maxValue : number = 99999
 +minValue : number = 0
-+description : string = This is a very long description that contains multiple words and should be preserved exactly as written in the transformation pipeline
++description : string = This is a very long description that contains multiple words<br/>and should be preserved exactly as written in the<br/>transformation pipeline
   }
     node1 --> node2 : config: "primary";, config=primary
 

--- a/test-output/generative/smart_task_prioritizer__context_management_.md
+++ b/test-output/generative/smart_task_prioritizer__context_management_.md
@@ -67,17 +67,17 @@ classDiagram-v2
 }
 
 namespace Tasks {
-  class analyze_tasks["You are helping prioritize a list of tasks. Here are the tasks: 1) Fix critical security bug, 2) Write documentation, 3) Implement new feature, 4) Code review. Analyze these tasks and use set_context_value to store a prioritized list in the 'analysis' context node with key 'prioritizedTasks' as a JSON string containing an array of objects with fields: task, priority (1-4), reasoning."] {
+  class analyze_tasks["You are helping prioritize a list of tasks. Here are the<br/>tasks: 1) Fix critical security bug, 2) Write documentation,<br/>3) Implement new feature, 4) Code review. Analyze these<br/>tasks and use set_context_value to store a prioritized list<br/>in the 'analysis' context node with key 'prioritizedTasks'<br/>as a JSON string containing an array of objects with fields:<br/>task, priority (1-4), reasoning."] {
     <<Task>>
     +meta = true
   }
 
-  class generate_action_plan["Read the prioritized tasks from 'analysis' context using get_context_value. Create a detailed action plan for the top 2 priority tasks. Use set_context_value to store the action plan in 'action_plan' context with key 'plan' as a string with clear steps for each task."] {
+  class generate_action_plan["Read the prioritized tasks from 'analysis' context using<br/>get_context_value. Create a detailed action plan for the top<br/>2 priority tasks. Use set_context_value to store the action<br/>plan in 'action_plan' context with key 'plan' as a string<br/>with clear steps for each task."] {
     <<Task>>
     +meta = true
   }
 
-  class finalize["Read the action plan from 'action_plan' context. Summarize the workflow completion and use the transition tool to move to 'complete' state."] {
+  class finalize["Read the action plan from 'action_plan' context. Summarize<br/>the workflow completion and use the transition tool to move<br/>to 'complete' state."] {
     <<Task>>
     +meta = true
   }


### PR DESCRIPTION
Implements text wrapping at 60 characters using <br/> tags for Mermaid class diagrams.

## Changes
- Added `wrapText()` helper function for word-wrapped text
- Applied to node labels (desc/prompt attributes)
- Applied to all attributes in class bodies
- Updated both MermaidGenerator and MarkdownGenerator

## Testing
- All 134 tests passing
- Verified wrapping in test outputs

Fixes #31

🤖 Generated with [Claude Code](https://claude.ai/code)