### PR TITLE
fix: generate Langium files before starting dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "build:web": "npm run build",
         "bundle": "vite build",
         "bundle:serve": "http-server ./dist --port 5175",
-        "dev": "vite",
+        "dev": "npm run langium:generate && vite",
         "dev:debug": "vite --debug --force",
         "serve": "npm run dev",
         "test": "vitest run",


### PR DESCRIPTION
## Summary
Fixed dynamic example loading in the CodeMirror playground by ensuring Langium-generated files are created before starting the dev server.

## Changes
- Updated `dev` script in package.json to run `langium:generate` before `vite`

## Testing
Validated with Playwright MCP:
- ✅ All 9 dynamic examples load correctly
- ✅ Example buttons work and load content
- ✅ Diagrams render properly

Fixes #36

Generated with [Claude Code](https://claude.ai/code)