### PR TITLE
Fix mobile playground collapsing sections behavior

### DIFF
--- a/playground-mobile.html
+++ b/playground-mobile.html
@@ -84,7 +84,12 @@
             display: flex;
             flex-direction: column;
             overflow: hidden;
-            border-bottom: 1px solid #3e3e42;
+            transition: flex 0.3s ease;
+        }
+
+        .editor-section.collapsed {
+            flex: 0 0 auto;
+            min-height: 0;
         }
 
         .section-header {
@@ -147,6 +152,12 @@
             flex-direction: column;
             overflow: hidden;
             background: #1e1e1e;
+            transition: flex 0.3s ease;
+        }
+
+        .output-section.collapsed {
+            flex: 0 0 auto;
+            min-height: 0;
         }
 
         #output {
@@ -223,7 +234,6 @@
             }
 
             .editor-section {
-                border-bottom: none;
                 border-right: 1px solid #3e3e42;
             }
 
@@ -239,7 +249,6 @@
             }
 
             .editor-section {
-                border-bottom: none;
                 border-right: 1px solid #3e3e42;
             }
         }
@@ -386,6 +395,14 @@
             } else {
                 content.classList.add('collapsed');
                 toggleBtn.textContent = '▶';
+            }
+
+            // Also toggle collapsed class on parent section for flex behavior
+            if (section === 'editor' || section === 'output') {
+                const parentSection = content.closest(`.${section}-section`);
+                if (parentSection) {
+                    parentSection.classList.toggle('collapsed');
+                }
             }
         };
 


### PR DESCRIPTION
Fixes #35

This PR addresses issues with the collapsing sections in the mobile playground:

## Changes
- Added CSS transitions and collapsed class handling for editor and output sections
- Sections now properly grow to fill available space when other sections collapse
- Removed extraneous border between sections in mobile view
- Added `min-height: 0` to collapsed sections to prevent taking up space
- Updated toggle function to apply collapsed class to parent sections

## Testing
- Validated with Playwright that sections properly expand to fill space
- Verified no extraneous spacing between sections
- Confirmed smooth transitions between states

Generated with [Claude Code](https://claude.ai/code)