### PR TITLE
fix: include example .dygram files in build output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,10 @@ export default defineConfig(() => {
                     {
                         src: 'static/styles/*',
                         dest: 'static/styles'
+                    },
+                    {
+                        src: 'examples/**/*.dygram',
+                        dest: 'examples'
                     }
                 ]
             })


### PR DESCRIPTION
## Summary
Fixed dynamic example loading on GitHub Pages by configuring Vite to copy example files to the build output.

## Root Cause
The vite.config.ts was not configured to copy example .dygram files to the dist directory, causing 404 errors on the deployed site.

## Changes
- Updated vite.config.ts to include `examples/**/*.dygram` in the static copy plugin

## Testing
Validated with Playwright MCP on deployed site:
- ✅ Identified 404 errors for 9 example files
- ✅ Confirmed examples exist in repository
- ✅ Fixed build configuration

Fixes #36

Generated with [Claude Code](https://claude.ai/code)