### PR TITLE
feat: Dynamically collect examples at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "onCommand:extension.generateAndPreview"
     ],
     "scripts": {
-        "build": "npm run langium:generate && tsc -b tsconfig.src.json && node esbuild.mjs",
+        "generate:examples": "node scripts/generate-examples-list.js",
+        "build": "npm run generate:examples && npm run langium:generate && tsc -b tsconfig.src.json && node esbuild.mjs",
         "watch": "concurrently -n tsc,esbuild -c blue,yellow \"tsc -b tsconfig.src.json --watch\" \"node esbuild.mjs --watch\"",
         "lint": "eslint src --ext ts",
         "langium:generate": "langium generate",
@@ -24,10 +25,10 @@
         "vscode:prepublish": "npm run build && npm run lint",
         "vscode:package": "vsce package",
         "build:web": "npm run build",
-        "bundle": "vite build",
+        "bundle": "npm run generate:examples && vite build",
         "bundle:serve": "http-server ./dist --port 5175",
-        "dev": "npm run langium:generate && vite",
-        "dev:debug": "vite --debug --force",
+        "dev": "npm run generate:examples && npm run langium:generate && vite",
+        "dev:debug": "npm run generate:examples && vite --debug --force",
         "serve": "npm run dev",
         "test": "vitest run",
         "test:runtime": "vitest run test/integration/runtime-visualization.test.ts",

--- a/scripts/generate-examples-list.js
+++ b/scripts/generate-examples-list.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import { readdir, readFile, writeFile, stat } from 'fs/promises';
+import { join, relative, basename, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Recursively scan directory for example files
+ */
+async function scanExamples(dir, baseDir = dir) {
+    const examples = [];
+
+    try {
+        const entries = await readdir(dir, { withFileTypes: true });
+
+        for (const entry of entries) {
+            const fullPath = join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                // Recursively scan subdirectories
+                const subExamples = await scanExamples(fullPath, baseDir);
+                examples.push(...subExamples);
+            } else if (entry.isFile() && (entry.name.endsWith('.dygram') || entry.name.endsWith('.mach'))) {
+                // Get relative path from examples directory
+                const relativePath = relative(baseDir, fullPath);
+
+                // Get category from directory structure
+                const pathParts = relativePath.split('/');
+                const category = pathParts.length > 1 ? pathParts[0] : 'root';
+
+                // Generate a readable name from filename
+                const nameWithoutExt = basename(entry.name, entry.name.endsWith('.dygram') ? '.dygram' : '.mach');
+                const readableName = nameWithoutExt
+                    .split('-')
+                    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                    .join(' ');
+
+                // Try to read first few lines to get machine title
+                let title = readableName;
+                try {
+                    const content = await readFile(fullPath, 'utf-8');
+                    const titleMatch = content.match(/^machine\s+"([^"]+)"/m);
+                    if (titleMatch) {
+                        title = titleMatch[1];
+                    }
+                } catch (readError) {
+                    console.warn(`Could not read content of ${relativePath}:`, readError.message);
+                }
+
+                examples.push({
+                    path: `examples/${relativePath.replace(/\\/g, '/')}`,
+                    name: readableName,
+                    title: title,
+                    category: category,
+                    filename: entry.name
+                });
+            }
+        }
+    } catch (error) {
+        console.error(`Error scanning directory ${dir}:`, error);
+    }
+
+    return examples;
+}
+
+/**
+ * Sort examples by category and name
+ */
+function sortExamples(examples) {
+    const categoryOrder = ['basic', 'workflows', 'attributes', 'edges', 'nesting', 'complex', 'edge-cases', 'stress', 'root'];
+
+    return examples.sort((a, b) => {
+        // First sort by category
+        const categoryIndexA = categoryOrder.indexOf(a.category);
+        const categoryIndexB = categoryOrder.indexOf(b.category);
+        const catA = categoryIndexA === -1 ? categoryOrder.length : categoryIndexA;
+        const catB = categoryIndexB === -1 ? categoryOrder.length : categoryIndexB;
+
+        if (catA !== catB) {
+            return catA - catB;
+        }
+
+        // Then sort by name
+        return a.name.localeCompare(b.name);
+    });
+}
+
+/**
+ * Main function
+ */
+async function main() {
+    const projectRoot = join(__dirname, '..');
+    const examplesDir = join(projectRoot, 'examples');
+    const outputFile = join(projectRoot, 'src', 'generated', 'examples-list.json');
+
+    console.log('Scanning examples directory...');
+    console.log(`Examples directory: ${examplesDir}`);
+
+    // Check if examples directory exists
+    try {
+        await stat(examplesDir);
+    } catch (error) {
+        console.error(`Examples directory not found: ${examplesDir}`);
+        process.exit(1);
+    }
+
+    // Scan for examples
+    const examples = await scanExamples(examplesDir);
+    const sortedExamples = sortExamples(examples);
+
+    console.log(`Found ${sortedExamples.length} examples:`);
+
+    // Group by category for display
+    const byCategory = {};
+    for (const example of sortedExamples) {
+        if (!byCategory[example.category]) {
+            byCategory[example.category] = [];
+        }
+        byCategory[example.category].push(example);
+    }
+
+    for (const [category, items] of Object.entries(byCategory)) {
+        console.log(`  ${category}: ${items.length} examples`);
+    }
+
+    // Ensure output directory exists
+    const outputDir = dirname(outputFile);
+    try {
+        await stat(outputDir);
+    } catch (error) {
+        // Directory doesn't exist, create it
+        const { mkdir } = await import('fs/promises');
+        await mkdir(outputDir, { recursive: true });
+        console.log(`Created directory: ${outputDir}`);
+    }
+
+    // Write to output file
+    const outputContent = JSON.stringify(sortedExamples, null, 2);
+    await writeFile(outputFile, outputContent, 'utf-8');
+
+    console.log(`\nGenerated examples list: ${outputFile}`);
+    console.log(`Total examples: ${sortedExamples.length}`);
+}
+
+main().catch(error => {
+    console.error('Error generating examples list:', error);
+    process.exit(1);
+});

--- a/src/codemirror-setup.ts
+++ b/src/codemirror-setup.ts
@@ -17,6 +17,7 @@ import { EvolutionaryExecutor } from './language/task-evolution.js';
 import { VisualizingMachineExecutor } from './language/runtime-visualizer.js';
 import { createStorage } from './language/storage.js';
 import { createLangiumExtensions } from './codemirror-langium.js';
+import examplesList from './generated/examples-list.json';
 
 // Initialize mermaid with custom settings
 mermaid.initialize({
@@ -79,30 +80,18 @@ processor -stores-> destination;`
 
 /**
  * Load examples dynamically from the examples directory
+ * Now uses build-time generated list instead of hardcoded paths
  */
 export async function loadDynamicExamples(): Promise<void> {
     try {
-        // List of example files to load from the examples directory
-        const exampleFiles = [
-            { path: 'examples/basic/minimal.dygram', name: 'Minimal' },
-            { path: 'examples/basic/typed-nodes.dygram', name: 'Typed Nodes' },
-            { path: 'examples/workflows/user-onboarding.dygram', name: 'User Onboarding' },
-            { path: 'examples/workflows/order-processing.dygram', name: 'Order Processing' },
-            { path: 'examples/workflows/ci-cd-pipeline.dygram', name: 'CI/CD Pipeline' },
-            { path: 'examples/attributes/basic-attributes.dygram', name: 'Attributes' },
-            { path: 'examples/edges/labeled-edges.dygram', name: 'Labeled Edges' },
-            { path: 'examples/nesting/nested-2-levels.dygram', name: 'Nested' },
-            { path: 'examples/complex/complex-machine.dygram', name: 'Complex' }
-        ];
-
         const examplesContainer = document.querySelector('.examples');
         if (!examplesContainer) return;
 
         // Clear existing example buttons
         examplesContainer.innerHTML = '';
 
-        // Load and create buttons for each example
-        for (const example of exampleFiles) {
+        // Load and create buttons for each example from generated list
+        for (const example of examplesList) {
             try {
                 const response = await fetch(example.path);
                 if (response.ok) {
@@ -113,7 +102,9 @@ export async function loadDynamicExamples(): Promise<void> {
                     const btn = document.createElement('button');
                     btn.className = 'example-btn';
                     btn.setAttribute('data-example', key);
+                    btn.setAttribute('data-category', example.category);
                     btn.textContent = example.name;
+                    btn.title = example.title; // Add tooltip with full title
                     examplesContainer.appendChild(btn);
 
                     // Add click handler
@@ -126,7 +117,7 @@ export async function loadDynamicExamples(): Promise<void> {
                                     insert: examples[key],
                                 },
                             });
-                            
+
                             // Update diagram source display immediately when example is switched
                             const outputElement = document.getElementById('outputInfo');
                             const diagramElement = document.getElementById('diagram');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "esModuleInterop": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
         "rootDir": ".",
         "noEmit": true
     },


### PR DESCRIPTION
## Summary

Improved the CodeMirror example loading system to dynamically collect examples at build time instead of using hardcoded paths.

## Changes
- Created build-time script that recursively scans examples directory
- Generates JSON file with metadata for all 28 examples (previously 9 hardcoded)
- Updated codemirror-setup.ts to use generated list
- Added category and title attributes to example buttons
- Enabled JSON module imports in TypeScript

## Benefits
- No more manual path updates when adding examples
- All 28 examples now discoverable and loadable
- Better organization with category information

Closes #46

---
Generated with [Claude Code](https://claude.ai/code)