### PR TITLE
Fix phase2 and phase3 examples not loading in playground

### DIFF
--- a/scripts/generate-examples-list.js
+++ b/scripts/generate-examples-list.js
@@ -70,7 +70,7 @@ async function scanExamples(dir, baseDir = dir) {
  * Sort examples by category and name
  */
 function sortExamples(examples) {
-    const categoryOrder = ['basic', 'workflows', 'attributes', 'edges', 'nesting', 'complex', 'edge-cases', 'stress', 'root'];
+    const categoryOrder = ['basic', 'workflows', 'attributes', 'edges', 'nesting', 'complex', 'phase2', 'phase3', 'edge-cases', 'stress', 'root'];
 
     return examples.sort((a, b) => {
         // First sort by category

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,14 @@ export default defineConfig(() => {
                         dest: 'examples'
                     },
                     {
+                        src: 'examples/phase2',
+                        dest: 'examples'
+                    },
+                    {
+                        src: 'examples/phase3',
+                        dest: 'examples'
+                    },
+                    {
                         src: 'examples/stress',
                         dest: 'examples'
                     },


### PR DESCRIPTION
## Summary

Fixed Phase 2 and Phase 3 examples not loading in the CodeMirror playground.

## Root Cause

The `viteStaticCopy` plugin configuration in `vite.config.ts` was missing the `phase2` and `phase3` example directories. When users clicked on Phase 2/3 examples, the files were not being served, resulting in 404 errors.

## Changes

1. Added `phase2` and `phase3` directories to the Vite static copy configuration
2. Added `phase2` and `phase3` to the category sort order for better organization

## Testing

All 6 Phase 2/3 examples now load correctly in the playground.

Resolves #56

---

Generated with [Claude Code](https://claude.ai/code)