### PR TITLE
feat: implement explicit edge-based context access control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "machine-lang",
-    "version": "0.3.0",
+    "version": "0.3.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "machine-lang",
-            "version": "0.3.0",
+            "version": "0.3.5",
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.32.1",
                 "@aws-sdk/client-bedrock-runtime": "^3.535.0",


### PR DESCRIPTION
## Summary

Implements explicit edge-based context access control as proposed in #61.

## Changes

- ✅ Context tools now filtered by explicit edges between tasks and contexts
- ✅ Permission model: write-oriented edge labels grant write access
- ✅ Runtime permission checks with helpful error messages
- ✅ Validation warnings for missing explicit connections
- ✅ Existing examples already have correct edges

## Breaking Changes

Tasks can no longer access context nodes without explicit edges. Machines that rely on implicit context access will need to add edges.

Closes #61

Generated with [Claude Code](https://claude.ai/code)