### PR TITLE
fix: remove non-existent examples/*.mach copy target from vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,10 +100,6 @@ export default defineConfig(() => {
                         dest: 'examples'
                     },
                     {
-                        src: 'examples/*.mach',
-                        dest: 'examples'
-                    },
-                    {
                         src: 'examples/README.md',
                         dest: 'examples'
                     }


### PR DESCRIPTION
Fixes the GitHub Pages deployment build failure.

The vite-plugin-static-copy was failing because it tried to copy `examples/*.mach` files, but there are no .mach files at the root of the examples directory. All .mach files are in subdirectories which are already being copied individually.

Fixes #75

---

Generated with [Claude Code](https://claude.ai/code)