### PR TITLE
fix: remove unused @ts-expect-error directive in meta-tool-manager

### DIFF
--- a/src/language/meta-tool-manager.ts
+++ b/src/language/meta-tool-manager.ts
@@ -41,7 +41,6 @@ export class MetaToolManager {
     private onMachineUpdate?: (dsl: string, machineData: MachineData) => void;
 
     constructor(
-        // @ts-expect-error - Reserved for future use
         private _machineData: MachineData,
         private onMutation: (mutation: Omit<MachineMutation, 'timestamp'>) => void
     ) {}


### PR DESCRIPTION
## Summary
Fixed the GitHub Pages deployment build failure by removing an unused `@ts-expect-error` directive.

## Changes
- Removed unused `@ts-expect-error` directive from `_machineData` constructor parameter in `meta-tool-manager.ts`
- The parameter is actively used throughout the class, so the error suppression was unnecessary

## Testing
- ✅ `npm run build` passes
- ✅ `npm run bundle` passes
- ✅ All assets generated correctly

Fixes #96

Generated with [Claude Code](https://claude.ai/code)