### PR TITLE
fix: improve type safety in type-checker.ts

### DIFF
--- a/test/validating/phase4-type-checking.test.ts
+++ b/test/validating/phase4-type-checking.test.ts
@@ -114,13 +114,12 @@ describe('Phase 4: Type Inference', () => {
         expect(inferredType).toBe('Array<string>');
     });
 
-    it('should handle empty arrays', () => {
+    it('should reject empty arrays without explicit type annotation', () => {
         const machine = { nodes: [], edges: [] } as any;
         const typeChecker = new TypeChecker(machine);
 
         const value = { value: [] };
-        const inferredType = typeChecker.inferType(value as any);
-        expect(inferredType).toBe('Array<any>');
+        expect(() => typeChecker.inferType(value as any)).toThrow('Unable to infer type for empty array');
     });
 });
 


### PR DESCRIPTION
## Summary
- Remove implicit 'any' returns from inferType method
- Add fail-fast error handling for invalid AST nodes
- Replace any type assertions with proper type guards
- Add homogeneous array type validation
- Update tests to expect errors for empty arrays

Addresses #116

🤖 Generated with [Claude Code](https://claude.ai/code)