### PR TITLE
refactor: Extract duplicated edge condition extraction logic

### DIFF
--- a/src/language/agent-context-builder.ts
+++ b/src/language/agent-context-builder.ts
@@ -9,8 +9,8 @@
  */
 
 import type { MachineData, MachineExecutionContext } from './rails-executor.js';
-import { extractValueFromAST } from './utils/ast-helpers.js';
 import { NodeTypeChecker } from './node-type-checker.js';
+import { EdgeConditionParser } from './utils/edge-conditions.js';
 
 /**
  * Context access permissions for a node
@@ -331,28 +331,14 @@ export class AgentContextBuilder {
      * Extract condition from edge label
      */
     private extractConditionFromLabel(edge: Edge): string | undefined {
-        const label = edge.label || edge.type || '';
-
-        const whenMatch = label.match(/when:\s*['"]?([^'"]+)['"]?/i);
-        if (whenMatch) return whenMatch[1].trim();
-
-        const unlessMatch = label.match(/unless:\s*['"]?([^'"]+)['"]?/i);
-        if (unlessMatch) return `!(${unlessMatch[1].trim()})`;
-
-        const ifMatch = label.match(/if:\s*['"]?([^'"]+)['"]?/i);
-        if (ifMatch) return ifMatch[1].trim();
-
-        return undefined;
+        return EdgeConditionParser.extract(edge);
     }
 
     /**
      * Check if condition is simple/deterministic
      */
     private isSimpleCondition(condition: string): boolean {
-        return !condition.includes('tool') &&
-               !condition.includes('external') &&
-               !condition.includes('api') &&
-               !condition.includes('call');
+        return EdgeConditionParser.isSimpleCondition(condition);
     }
 
     /**

--- a/src/language/base-executor.ts
+++ b/src/language/base-executor.ts
@@ -10,6 +10,7 @@ import {
 import { BedrockClient } from './bedrock-client.js';
 import { extractValueFromAST, parseAttributeValue, serializeValue, validateValueType } from './utils/ast-helpers.js';
 import { NodeTypeChecker } from './node-type-checker.js';
+import { EdgeConditionParser } from './utils/edge-conditions.js';
 
 // Shared interfaces
 export interface MachineExecutionContext {
@@ -145,29 +146,10 @@ export abstract class BaseExecutor {
 
     /**
      * Extract condition from edge label (when, unless, if)
+     * @deprecated Use EdgeConditionParser.extract() directly for new code
      */
     protected extractEdgeCondition(edge: { label?: string; type?: string }): string | undefined {
-        const edgeLabel = edge.label || edge.type || '';
-
-        // Look for when: pattern (case-insensitive match, but preserve condition case)
-        const whenMatch = edgeLabel.match(/when:\s*['"]?([^'"]+)['"]?/i);
-        if (whenMatch) {
-            return whenMatch[1].trim();
-        }
-
-        // Look for unless: pattern (negate it, case-insensitive match, but preserve condition case)
-        const unlessMatch = edgeLabel.match(/unless:\s*['"]?([^'"]+)['"]?/i);
-        if (unlessMatch) {
-            return `!(${unlessMatch[1].trim()})`;
-        }
-
-        // Look for if: pattern (case-insensitive match, but preserve condition case)
-        const ifMatch = edgeLabel.match(/if:\s*['"]?([^'"]+)['"]?/i);
-        if (ifMatch) {
-            return ifMatch[1].trim();
-        }
-
-        return undefined;
+        return EdgeConditionParser.extract(edge);
     }
 
     /**

--- a/src/language/rails-executor.ts
+++ b/src/language/rails-executor.ts
@@ -22,6 +22,7 @@ import {
     MachineMutation,
     MachineExecutorConfig as BaseMachineExecutorConfig
 } from './base-executor.js';
+import { EdgeConditionParser } from './utils/edge-conditions.js';
 
 // Re-export interfaces for compatibility
 export type { MachineExecutionContext, MachineData, MachineMutation };
@@ -166,16 +167,10 @@ export class RailsExecutor extends BaseExecutor {
 
     /**
      * Check if condition is simple (deterministic, no external data)
+     * @deprecated Use EdgeConditionParser.isSimpleCondition() directly for new code
      */
     protected isSimpleCondition(condition: string | undefined): boolean {
-        if (!condition) return true;
-
-        // Conditions that only reference context attributes and runtime state are simple
-        // Complex conditions require tool calls or external data
-        return !condition.includes('tool') &&
-               !condition.includes('external') &&
-               !condition.includes('api') &&
-               !condition.includes('call');
+        return EdgeConditionParser.isSimpleCondition(condition);
     }
 
 

--- a/src/language/utils/edge-conditions.ts
+++ b/src/language/utils/edge-conditions.ts
@@ -1,0 +1,71 @@
+/**
+ * Edge Condition Parser - Shared utility for extracting and evaluating edge conditions
+ *
+ * Handles edge condition patterns like:
+ * - when: <condition>
+ * - unless: <condition>
+ * - if: <condition>
+ */
+
+/**
+ * Edge interface (minimal)
+ */
+export interface Edge {
+    label?: string;
+    type?: string;
+}
+
+/**
+ * Edge Condition Parser
+ */
+export class EdgeConditionParser {
+    /**
+     * Extract condition from edge label (when, unless, if)
+     *
+     * @param edge - Edge with optional label or type
+     * @returns Extracted condition string, or undefined if no condition found
+     */
+    static extract(edge: Edge): string | undefined {
+        const edgeLabel = edge.label || edge.type || '';
+
+        // Look for when: pattern (case-insensitive match, but preserve condition case)
+        const whenMatch = edgeLabel.match(/when:\s*['"]?([^'"]+)['"]?/i);
+        if (whenMatch) {
+            return whenMatch[1].trim();
+        }
+
+        // Look for unless: pattern (negate it, case-insensitive match, but preserve condition case)
+        const unlessMatch = edgeLabel.match(/unless:\s*['"]?([^'"]+)['"]?/i);
+        if (unlessMatch) {
+            return `!(${unlessMatch[1].trim()})`;
+        }
+
+        // Look for if: pattern (case-insensitive match, but preserve condition case)
+        const ifMatch = edgeLabel.match(/if:\s*['"]?([^'"]+)['"]?/i);
+        if (ifMatch) {
+            return ifMatch[1].trim();
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Check if condition is simple/deterministic (does not require external calls)
+     *
+     * Simple conditions only reference context attributes and runtime state.
+     * Complex conditions require tool calls, API calls, or external data.
+     *
+     * @param condition - Condition string to check
+     * @returns true if condition is simple/deterministic, false otherwise
+     */
+    static isSimpleCondition(condition: string | undefined): boolean {
+        if (!condition) return true;
+
+        // Conditions that only reference context attributes and runtime state are simple
+        // Complex conditions require tool calls or external data
+        return !condition.includes('tool') &&
+               !condition.includes('external') &&
+               !condition.includes('api') &&
+               !condition.includes('call');
+    }
+}


### PR DESCRIPTION
## Summary

Extracts duplicated edge condition extraction logic into a shared utility class.

## Changes

- Created `EdgeConditionParser` utility class in `src/language/utils/edge-conditions.ts`
- Extracted duplicated when:/unless:/if: regex patterns from 3 files
- Extracted duplicated `isSimpleCondition()` logic
- Refactored `base-executor.ts`, `rails-executor.ts`, and `agent-context-builder.ts`
- Marked old methods as deprecated
- Eliminated ~60 lines of duplicated code

## Testing

- Build: ✅ Succeeded
- Tests: ✅ 439/440 passed (pre-existing failures unrelated)

Fixes #105

Generated with [Claude Code](https://claude.ai/code)