### PR TITLE
feat: Add Tool node support with meta-programming capabilities

### DIFF
--- a/examples/meta-programming/tool-creation.dygram
+++ b/examples/meta-programming/tool-creation.dygram
@@ -1,0 +1,35 @@
+machine "Tool Creation Example"
+
+// Demonstrates dynamic tool construction with loosely defined Tool nodes
+// When meta: true is enabled, the agent can build out tool definitions
+
+// A loosely defined tool - just has a name and basic description
+Tool sentiment_analyzer {
+    description: "Analyze sentiment of text and return score";
+}
+
+// A more complete tool with input schema but no implementation
+Tool data_transformer {
+    description: "Transform data from one format to another";
+    input_schema: '{"type": "object", "properties": {"data": {"type": "string"}, "target_format": {"type": "string"}}}';
+}
+
+// Task with meta capability to build out tools
+Task builder {
+    meta: true;
+    prompt: "Inspect the tool nodes (sentiment_analyzer and data_transformer). For each tool, use construct_tool to register them with complete input_schema, output_schema, and an implementation strategy. For sentiment_analyzer, use 'agent_backed' strategy. For data_transformer, use 'code_generation' strategy with sample JavaScript code.";
+}
+
+// Task that will use the tools after they are built
+Task processor {
+    prompt: "Use the sentiment_analyzer tool to analyze: 'This is a great product!'. Then use data_transformer to convert some sample JSON to YAML format.";
+}
+
+State complete {
+    desc: "Processing complete";
+}
+
+// Workflow
+builder -uses-> sentiment_analyzer, data_transformer;
+builder -> processor;
+processor -> complete;

--- a/src/language/agent-sdk-bridge.ts
+++ b/src/language/agent-sdk-bridge.ts
@@ -531,6 +531,10 @@ export class AgentSDKBridge {
                     return await this.metaToolManager.listAvailableTools(input);
                 case 'propose_tool_improvement':
                     return await this.metaToolManager.proposeToolImprovement(input);
+                case 'get_tool_nodes':
+                    return await this.metaToolManager.getToolNodesHandler(input);
+                case 'build_tool_from_node':
+                    return await this.metaToolManager.buildToolFromNodeHandler(input);
                 default:
                     throw new Error(`Meta-tool ${toolName} not implemented`);
             }

--- a/src/language/node-type-checker.ts
+++ b/src/language/node-type-checker.ts
@@ -86,6 +86,15 @@ export class NodeTypeChecker {
     }
 
     /**
+     * Check if a node is a tool node
+     * Tool nodes represent callable tools with input/output schemas
+     * Tools can be loosely defined (minimal attributes) or fully defined
+     */
+    static isTool(node: NodeLike | ASTNode): boolean {
+        return node.type?.toLowerCase() === 'tool';
+    }
+
+    /**
      * Check if a node requires agent decision
      * A node requires agent decision if:
      * 1. It's a task node with a prompt, OR


### PR DESCRIPTION
Implements #134 - Tool creation feature with loosely defined Tool nodes that can be built out dynamically by agents with meta: true.

## New Features
- Tool node type support in NodeTypeChecker
- MetaToolManager methods for Tool node operations
- New meta-tools: `get_tool_nodes` and `build_tool_from_node`
- AgentSDKBridge integration for new meta-tools
- Example: tool-creation.dygram demonstrating the feature
- Comprehensive test coverage (21 passing tests)
- Updated documentation with Tool node patterns

## Implementation
Tool nodes can be loosely defined (minimal attributes) and then completed by agents using three strategies:
- `agent_backed`: LLM executes the tool
- `code_generation`: JavaScript code execution
- `composition`: Combine existing tools

Generated with [Claude Code](https://claude.ai/code)