### PR TITLE
feat: Implement Phase 2 - State Modules with implicit entry/exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,10 +238,24 @@ DataPipeline -writes-> DataPipeline.pipelineState;
 ```
 
 **Key Features:**
-- **Qualified Names**: Reference nested nodes using dot notation (e.g., `Parent.Child.GrandChild`)
-- **Context Inheritance**: Child nodes automatically inherit read-only access to parent contexts
-- **Reduced Boilerplate**: No need for repetitive context edges on every child node
-- **Intuitive Scoping**: Hierarchical structure reflects natural context relationships
+- **Qualified Names** (Phase 1): Reference nested nodes using dot notation (e.g., `Parent.Child.GrandChild`)
+- **Context Inheritance** (Phase 1): Child nodes automatically inherit read-only access to parent contexts
+- **State Modules** (Phase 2): State nodes with children act as workflow modules with automatic entry/exit routing
+- **Reduced Boilerplate**: No need for repetitive context edges or explicit module wiring
+- **Intuitive Scoping**: Hierarchical structure reflects natural context and workflow relationships
+
+**Example - State Module:**
+```dygram
+state DataPipeline {
+    state validate -> process -> store;
+}
+
+// Transitioning to DataPipeline automatically enters at 'validate'
+start -> DataPipeline;
+
+// Terminal nodes inherit module-level exits
+DataPipeline -> complete;  // 'store' (terminal) transitions to 'complete'
+```
 
 See [Nesting Examples](examples/nesting/) for more details.
 

--- a/examples/nesting/README.md
+++ b/examples/nesting/README.md
@@ -4,10 +4,11 @@ This directory contains examples demonstrating DyGram's nesting and namespace fe
 
 ## Overview
 
-DyGram supports semantic nesting that goes beyond simple visual grouping. Nested nodes create hierarchical namespaces with two powerful features:
+DyGram supports semantic nesting that goes beyond simple visual grouping. Nested nodes create hierarchical namespaces with powerful features:
 
-1. **Qualified Names**: Reference nested nodes using dot notation (e.g., `Parent.Child`, `Level1.Level2.Node`)
-2. **Context Inheritance**: Child nodes automatically inherit read-only access to context nodes accessible by their parent nodes
+1. **Qualified Names** (Phase 1): Reference nested nodes using dot notation (e.g., `Parent.Child`, `Level1.Level2.Node`)
+2. **Context Inheritance** (Phase 1): Child nodes automatically inherit read-only access to context nodes accessible by their parent nodes
+3. **State Modules** (Phase 2): State nodes with children act as workflow modules with automatic entry/exit routing
 
 ## Basic Nesting
 
@@ -145,13 +146,23 @@ Complex nesting with multiple branches up to 4 levels deep.
 ### `deep-nested-5-levels.dygram`
 Demonstrates 5-level deep nesting to test parser depth limits.
 
-### `semantic-nesting-example.dygram` ⭐ **NEW**
-Comprehensive example showing:
+### `semantic-nesting-example.dygram` ⭐ **Phase 1**
+Comprehensive example showing qualified names and context inheritance:
 - Qualified names for referencing nested nodes
 - Context inheritance across multiple levels
 - Practical data pipeline with phases
 - Mix of inherited and explicit context access
 - Notes explaining the inheritance behavior
+
+### `state-modules-example.dygram` ⭐⭐ **Phase 2**
+Comprehensive example showing state modules and workflow composition:
+- State modules as workflow components
+- Module entry and exit routing
+- Nested modules (modules within modules)
+- Module composition patterns
+- Context inheritance with modules
+- Error handling across modules
+- Complete ETL pipeline example
 
 ## Key Benefits
 
@@ -193,6 +204,177 @@ Pipeline1.Task1 -> Pipeline2.Task1;  // Clear which tasks
 
 ### 4. Intuitive Context Access
 Context inheritance matches natural expectations - child contexts can see parent contexts, just like lexical scoping in programming languages.
+
+## State Modules (Phase 2)
+
+**State modules** are state nodes with children that act as workflow modules. They provide automatic entry/exit routing and enable powerful workflow composition patterns.
+
+### What is a State Module?
+
+A state module is simply a `state` node that contains child nodes:
+
+```dygram
+// This is a state module
+state DataPipeline {
+    state validate;
+    state process;
+    state store;
+
+    validate -> process -> store;
+}
+```
+
+### Module Entry
+
+When you transition to a state module, execution automatically enters at the **first child**:
+
+```dygram
+start -> DataPipeline;  // Automatically enters at 'validate' (first child)
+```
+
+**Entry Priority:**
+1. Task nodes (actual executable work)
+2. State nodes (can be entry points for nested modules)
+3. Other node types (avoids context nodes)
+
+### Module Exit
+
+Terminal nodes (those with no outbound edges) within a module automatically inherit the module-level exit edges:
+
+```dygram
+state Pipeline {
+    state task1 -> task2 -> task3;  // task3 is terminal
+}
+
+Pipeline -> complete;  // Module-level exit
+
+// When task3 completes, it inherits Pipeline's exit and transitions to 'complete'
+```
+
+**Explicit edges always take precedence** over inherited module exits.
+
+### Nested Modules
+
+Modules can contain other modules, creating hierarchical workflows:
+
+```dygram
+state OuterPipeline {
+    // Nested module
+    state ValidationPhase {
+        state check -> validate -> verify;
+    }
+
+    state ProcessingPhase {
+        state transform -> aggregate;
+    }
+
+    ValidationPhase -> ProcessingPhase;
+}
+
+// Transitioning to OuterPipeline:
+// OuterPipeline -> ValidationPhase -> check (enters nested module)
+```
+
+### Module Composition Patterns
+
+**Sequential Composition:**
+```dygram
+state ModuleA { /* ... */ }
+state ModuleB { /* ... */ }
+state ModuleC { /* ... */ }
+
+start -> ModuleA;
+ModuleA -> ModuleB;
+ModuleB -> ModuleC;
+ModuleC -> end;
+```
+
+**Conditional Composition:**
+```dygram
+state Validation { /* ... */ }
+state SuccessPath { /* ... */ }
+state ErrorPath { /* ... */ }
+
+start -> Validation;
+Validation -success-> SuccessPath;
+Validation -error-> ErrorPath;
+```
+
+**Module with Error Handling:**
+```dygram
+state Pipeline {
+    state task1 -> task2 -> task3;
+}
+
+task handleError;
+
+// Explicit error paths from specific tasks
+Pipeline.task2 -error-> handleError;
+
+// Module-level exit for success
+Pipeline -> complete;
+```
+
+### State Modules vs Simple States
+
+**Simple State** (no children):
+```dygram
+state ready;
+state processing;
+
+ready -> processing;  // Normal state transition
+```
+
+**State Module** (with children):
+```dygram
+state ProcessingModule {
+    state step1 -> step2;
+}
+
+ready -> ProcessingModule;  // Enters at step1
+```
+
+Simple states work exactly as before - only state nodes with children gain module semantics.
+
+### Benefits of State Modules
+
+1. **Encapsulation**: Group related workflow steps into logical modules
+2. **Reusability**: Define reusable sub-workflows
+3. **Composition**: Build complex workflows from simpler modules
+4. **Clarity**: Make workflow structure explicit and hierarchical
+5. **Automatic Routing**: No need to explicitly wire entry/exit points
+
+### Example: ETL Pipeline with Modules
+
+```dygram
+machine "ETL Pipeline"
+
+// Each phase is a state module
+state Extract {
+    state fetchData -> validateSource;
+}
+
+state Transform {
+    state cleanData -> enrichData -> aggregate;
+}
+
+state Load {
+    state prepareTarget -> writeData -> verifyLoad;
+}
+
+// Compose modules
+init start;
+start -> Extract;
+Extract -> Transform;
+Transform -> Load;
+Load -> complete;
+```
+
+When this executes:
+1. `start -> Extract` enters at `Extract.fetchData`
+2. `Extract.validateSource` (terminal) transitions to `Transform.cleanData`
+3. `Transform.aggregate` (terminal) transitions to `Load.prepareTarget`
+4. `Load.verifyLoad` (terminal) transitions to `complete`
 
 ## Usage Notes
 

--- a/test/integration/state-modules.test.ts
+++ b/test/integration/state-modules.test.ts
@@ -1,0 +1,360 @@
+/**
+ * State Modules Tests - Phase 2
+ *
+ * Tests for state nodes with children acting as workflow modules:
+ * - Module entry at first child
+ * - Module exit from terminal nodes
+ * - Module composition
+ * - Nested modules
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RailsExecutor, MachineData } from '../../src/language/rails-executor.js';
+import { AgentContextBuilder } from '../../src/language/agent-context-builder.js';
+
+describe('State Modules', () => {
+    describe('Module Entry', () => {
+        it('should enter state module at first child task', async () => {
+            const machineData: MachineData = {
+                title: 'State Module Entry Test',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    { name: 'Validation', type: 'state' }, // State module
+                    { name: 'check', type: 'task', parent: 'Validation' }, // First child
+                    { name: 'sanitize', type: 'task', parent: 'Validation' },
+                    { name: 'end', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'Validation' }, // Transition to module
+                    { source: 'check', target: 'sanitize' }, // Within module
+                    { source: 'sanitize', target: 'end' } // Exit module
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+            executor.context.currentNode = 'start';
+
+            // Transition to module should route to first child
+            await executor.step();
+
+            // Should be at 'check' (first child of Validation)
+            expect(executor.context.currentNode).toBe('check');
+            expect(executor.context.activeState).toBe('Validation');
+
+            // History should show module entry
+            const history = executor.context.history;
+            expect(history.some(h => h.to === 'Validation')).toBe(true);
+            expect(history.some(h => h.from === 'Validation' && h.to === 'check')).toBe(true);
+        });
+
+        it('should prefer task nodes as entry points', async () => {
+            const machineData: MachineData = {
+                title: 'State Module Entry Preference Test',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    { name: 'Module', type: 'state' },
+                    { name: 'config', type: 'context', parent: 'Module' }, // First child (context)
+                    { name: 'process', type: 'task', parent: 'Module' }, // Second child (task)
+                    { name: 'end', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'Module' },
+                    { source: 'process', target: 'end' }
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+            executor.context.currentNode = 'start';
+
+            await executor.step();
+
+            // Should enter at 'process' (task node), not 'config' (context node)
+            expect(executor.context.currentNode).toBe('process');
+        });
+
+        it('should handle simple state nodes without children normally', async () => {
+            const machineData: MachineData = {
+                title: 'Simple State Node Test',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    { name: 'ready', type: 'state' }, // Simple state (no children)
+                    { name: 'process', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'ready' },
+                    { source: 'ready', target: 'process' }
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+            executor.context.currentNode = 'start';
+
+            await executor.step();
+
+            // Should be at 'ready' (not auto-routed anywhere)
+            expect(executor.context.currentNode).toBe('ready');
+
+            // Next step should auto-transition to 'process'
+            await executor.step();
+            expect(executor.context.currentNode).toBe('process');
+        });
+    });
+
+    describe('Module Exit', () => {
+        it('should inherit module-level exit edges from terminal nodes', async () => {
+            const machineData: MachineData = {
+                title: 'State Module Exit Test',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    { name: 'Processing', type: 'state' },
+                    { name: 'task1', type: 'state', parent: 'Processing' }, // State node auto-transitions
+                    { name: 'task2', type: 'state', parent: 'Processing' }, // Terminal state node
+                    { name: 'complete', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'Processing' },
+                    { source: 'task1', target: 'task2' }, // Within module
+                    { source: 'Processing', target: 'complete' } // Module-level exit
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+            executor.context.currentNode = 'start';
+
+            // Execute through the module
+            await executor.step(); // start -> Processing -> task1
+            expect(executor.context.currentNode).toBe('task1');
+
+            await executor.step(); // task1 -> task2
+            expect(executor.context.currentNode).toBe('task2');
+
+            // task2 is terminal within module, should inherit module exit
+            await executor.step(); // task2 -> complete (via module exit)
+            expect(executor.context.currentNode).toBe('complete');
+        });
+
+        it('should prioritize explicit edges over module-level exits', async () => {
+            const machineData: MachineData = {
+                title: 'Explicit Edge Priority Test',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    { name: 'Module', type: 'state' },
+                    { name: 'task1', type: 'state', parent: 'Module' }, // State nodes auto-transition
+                    { name: 'task2', type: 'state', parent: 'Module' },
+                    { name: 'explicitTarget', type: 'task' },
+                    { name: 'moduleTarget', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'Module' },
+                    { source: 'task1', target: 'task2' },
+                    { source: 'task2', target: 'explicitTarget' }, // Explicit edge from child
+                    { source: 'Module', target: 'moduleTarget' } // Module-level exit (ignored)
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+            executor.context.currentNode = 'start';
+
+            await executor.step(); // start -> Module -> task1
+            await executor.step(); // task1 -> task2
+            await executor.step(); // task2 -> explicitTarget (not moduleTarget)
+
+            expect(executor.context.currentNode).toBe('explicitTarget');
+        });
+    });
+
+    describe('Module Composition', () => {
+        it('should support sequential module composition', async () => {
+            const machineData: MachineData = {
+                title: 'Sequential Module Composition',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    // Module 1
+                    { name: 'Validation', type: 'state' },
+                    { name: 'validate', type: 'state', parent: 'Validation' }, // State nodes auto-transition
+                    // Module 2
+                    { name: 'Processing', type: 'state' },
+                    { name: 'process', type: 'state', parent: 'Processing' },
+                    // Module 3
+                    { name: 'Storage', type: 'state' },
+                    { name: 'store', type: 'state', parent: 'Storage' },
+                    { name: 'end', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'Validation' },
+                    { source: 'Validation', target: 'Processing' },
+                    { source: 'Processing', target: 'Storage' },
+                    { source: 'Storage', target: 'end' }
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+            executor.context.currentNode = 'start';
+
+            await executor.step(); // start -> Validation -> validate
+            expect(executor.context.currentNode).toBe('validate');
+            expect(executor.context.activeState).toBe('Validation');
+
+            await executor.step(); // validate -> Processing -> process
+            expect(executor.context.currentNode).toBe('process');
+            expect(executor.context.activeState).toBe('Processing');
+
+            await executor.step(); // process -> Storage -> store
+            expect(executor.context.currentNode).toBe('store');
+            expect(executor.context.activeState).toBe('Storage');
+
+            await executor.step(); // store -> end
+            expect(executor.context.currentNode).toBe('end');
+        });
+
+        it('should support conditional module transitions', async () => {
+            const machineData: MachineData = {
+                title: 'Conditional Module Transitions',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    { name: 'Validation', type: 'state' },
+                    { name: 'validate', type: 'task', parent: 'Validation' },
+                    { name: 'SuccessPath', type: 'state' },
+                    { name: 'success', type: 'task', parent: 'SuccessPath' },
+                    { name: 'ErrorPath', type: 'state' },
+                    { name: 'error', type: 'task', parent: 'ErrorPath' },
+                    { name: 'end', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'Validation' },
+                    { source: 'Validation', target: 'SuccessPath', label: 'success' },
+                    { source: 'Validation', target: 'ErrorPath', label: 'error' },
+                    { source: 'SuccessPath', target: 'end' },
+                    { source: 'ErrorPath', target: 'end' }
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+            executor.context.currentNode = 'start';
+
+            await executor.step(); // start -> Validation -> validate
+            expect(executor.context.currentNode).toBe('validate');
+
+            // validate is terminal in Validation module
+            // Should have two available transitions (success/error paths)
+            const transitions = executor['getNonAutomatedTransitions']('validate');
+            expect(transitions.length).toBe(2);
+            expect(transitions.map(t => t.target)).toContain('SuccessPath');
+            expect(transitions.map(t => t.target)).toContain('ErrorPath');
+        });
+    });
+
+    describe('Nested Modules', () => {
+        it('should support nested state modules', async () => {
+            const machineData: MachineData = {
+                title: 'Nested State Modules',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    // Outer module
+                    { name: 'Pipeline', type: 'state' },
+                    // Inner module (nested within Pipeline)
+                    { name: 'Validation', type: 'state', parent: 'Pipeline' },
+                    { name: 'validate', type: 'state', parent: 'Validation' }, // State nodes auto-transition
+                    { name: 'process', type: 'state', parent: 'Pipeline' },
+                    { name: 'end', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'Pipeline' },
+                    { source: 'Validation', target: 'process' },
+                    { source: 'Pipeline', target: 'end' }
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+            executor.context.currentNode = 'start';
+
+            // Transition to outer module should enter inner module (first child)
+            await executor.step(); // start -> Pipeline -> Validation (enters at Validation since it's first child)
+
+            // Since getFirstChild prefers task nodes, and Validation is a state module,
+            // it will enter Validation module, which then enters at validate
+            // This test demonstrates nested module entry
+            expect(executor.context.currentNode).toBe('validate');
+            expect(executor.context.activeState).toBe('Validation');
+
+            // Exit inner module
+            await executor.step(); // validate -> process (via Validation module exit)
+            expect(executor.context.currentNode).toBe('process');
+
+            // Exit outer module
+            await executor.step(); // process -> end (via Pipeline module exit)
+            expect(executor.context.currentNode).toBe('end');
+        });
+    });
+
+    describe('Module Context Inheritance', () => {
+        it('should inherit context from parent state module', async () => {
+            const machineData: MachineData = {
+                title: 'Module Context Inheritance',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    { name: 'config', type: 'context', attributes: [{ name: 'apiUrl', type: 'string', value: '"https://api.example.com"' }] },
+                    { name: 'Pipeline', type: 'state' },
+                    { name: 'pipelineState', type: 'context', parent: 'Pipeline', attributes: [{ name: 'status', type: 'string', value: '"running"' }] },
+                    { name: 'task1', type: 'task', parent: 'Pipeline', attributes: [{ name: 'prompt', type: 'string', value: '"Process data"' }] },
+                    { name: 'end', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'Pipeline' },
+                    { source: 'Pipeline', target: 'config', label: 'reads' }, // Module reads config
+                    { source: 'task1', target: 'pipelineState', label: 'reads' }, // Task reads pipeline state
+                    { source: 'Pipeline', target: 'end' }
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+
+            // Use AgentContextBuilder directly
+            const builder = new AgentContextBuilder(machineData, executor.context);
+
+            // task1 should inherit read access to config from Pipeline
+            const contexts = builder.getAccessibleContextNodes('task1');
+
+            expect(contexts.has('config')).toBe(true);
+            expect(contexts.get('config')?.canRead).toBe(true);
+
+            // task1 should also have explicit access to pipelineState
+            expect(contexts.has('pipelineState')).toBe(true);
+            expect(contexts.get('pipelineState')?.canRead).toBe(true);
+        });
+    });
+
+    describe('Backward Compatibility', () => {
+        it('should maintain backward compatibility with non-module state nodes', async () => {
+            const machineData: MachineData = {
+                title: 'Backward Compatibility Test',
+                nodes: [
+                    { name: 'start', type: 'init' },
+                    { name: 'ready', type: 'state' },
+                    { name: 'processing', type: 'state' },
+                    { name: 'complete', type: 'state' },
+                    { name: 'task1', type: 'task' }
+                ],
+                edges: [
+                    { source: 'start', target: 'ready' },
+                    { source: 'ready', target: 'processing' },
+                    { source: 'processing', target: 'task1' },
+                    { source: 'task1', target: 'complete' }
+                ]
+            };
+
+            const executor = new RailsExecutor(machineData);
+            executor.context.currentNode = 'start';
+
+            // Should auto-transition through simple states as before
+            await executor.step(); // start -> ready
+            expect(executor.context.currentNode).toBe('ready');
+
+            await executor.step(); // ready -> processing (auto-transition)
+            expect(executor.context.currentNode).toBe('processing');
+
+            await executor.step(); // processing -> task1 (auto-transition)
+            expect(executor.context.currentNode).toBe('task1');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Implements Phase 2 of semantic nesting proposal from issue #152.

### Features
- **State Modules**: State nodes with children act as workflow modules
- **Automatic Entry**: Module entry routes to first child (task > state > other)
- **Automatic Exit**: Terminal nodes inherit module-level exits
- **Nested Modules**: Recursive module entry for hierarchical workflows
- **Workflow Composition**: Sequential, conditional, and error handling patterns
- All 470 tests passing

### Changes
- **rails-executor.ts**: Module entry/exit logic, recursive nesting
- **Tests**: 10 comprehensive tests for state modules
- **Docs**: Comprehensive documentation and examples
- **Backward Compatible**: No breaking changes

Progresses #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)