### PR TITLE
feat: Phase 2.3 - Visualization enhancements for semantic nesting

### DIFF
--- a/examples/nesting/state-modules-example.dygram
+++ b/examples/nesting/state-modules-example.dygram
@@ -1,0 +1,118 @@
+machine "State Modules Example - ETL Pipeline"
+
+// Global configuration context
+context globalConfig {
+    apiUrl: "https://api.example.com";
+    timeout: 5000;
+    environment: "production";
+}
+
+// State module for data extraction
+state Extract "Data Extraction Module" {
+    state fetchData "Fetch from API" {
+        prompt: "Fetch data from the API endpoint";
+    }
+
+    state validateSource "Validate Source Data" {
+        prompt: "Validate that source data is complete and well-formed";
+    }
+
+    // Internal flow within Extract module
+    fetchData -> validateSource;
+}
+
+// State module for data transformation
+state Transform "Data Transformation Module" {
+    context transformConfig {
+        batchSize: 1000;
+        parallelism: 4;
+    }
+
+    state cleanData "Clean Data" {
+        prompt: "Remove invalid entries and normalize data";
+    }
+
+    state enrichData "Enrich Data" {
+        prompt: "Add calculated fields and enrichments";
+    }
+
+    state aggregate "Aggregate Results" {
+        prompt: "Aggregate data by specified dimensions";
+    }
+
+    // Internal flow within Transform module
+    cleanData -> enrichData -> aggregate;
+}
+
+// State module for data loading
+state Load "Data Loading Module" {
+    context loadConfig {
+        targetDatabase: "warehouse";
+        writeMode: "append";
+    }
+
+    state prepareTarget "Prepare Target" {
+        prompt: "Ensure target table exists and is ready";
+    }
+
+    state writeData "Write Data" {
+        prompt: "Write processed data to target";
+    }
+
+    state verifyLoad "Verify Load" {
+        prompt: "Verify all data was loaded correctly";
+    }
+
+    // Internal flow within Load module
+    prepareTarget -> writeData -> verifyLoad;
+}
+
+// Entry and exit points for the pipeline
+init start;
+state complete;
+state failed;
+
+// Module composition - entry points are automatically determined
+// Entering Extract module goes to Extract.fetchData (first task)
+start -> Extract;
+
+// Module exits - when validateSource completes, transition to Transform
+// Transform module entry goes to Transform.cleanData (first task)
+Extract -> Transform;
+
+// When aggregate completes, transition to Load
+// Load module entry goes to Load.prepareTarget (first task)
+Transform -> Load;
+
+// When verifyLoad completes, transition to complete
+// This demonstrates module-level exit routing
+Load -> complete;
+
+// Error handling - specific nodes can have explicit error paths
+Extract.fetchData -error-> failed;
+Transform.cleanData -error-> failed;
+Load.writeData -error-> failed;
+
+// Context relationships
+// Extract module reads global config
+Extract -reads-> globalConfig;
+
+// Transform reads config and has its own context
+Transform -reads-> globalConfig;
+
+// Load reads config and has its own context
+Load -reads-> globalConfig;
+
+// Child nodes within each module inherit parent context access automatically
+// For example, Extract.fetchData can read globalConfig without explicit edge
+// Transform.cleanData can read both globalConfig and Transform.transformConfig
+
+note for Extract "State module with automatic entry at fetchData. Terminal node validateSource inherits parent's exit edge to Transform."
+
+note for Transform "Nested state module with internal context. Entry at cleanData, exit from aggregate to Load module."
+
+note for Load "State module demonstrating context inheritance. Child nodes inherit access to both globalConfig and loadConfig."
+
+note for start "Pipeline starts here and enters the Extract module at its first child (fetchData)."
+
+note for Extract.validateSource "Terminal node within Extract module. No explicit outbound edge, so it inherits the module-level exit to Transform."


### PR DESCRIPTION
## Summary

Implements Phase 2.3 visualization enhancements from issue #152.

### Features
- **Parent Annotations**: Show hierarchical relationships in diagrams
- **State Module Indicators**: `<<module>>` stereotype for state nodes with children
- **Inherited Context Visualization**: Dashed edges show implicit context access
- **State Modules Example**: Comprehensive ETL pipeline demonstrating features
- All 470 tests passing

### Changes
- **generator.ts**: Enhanced Mermaid visualization with hierarchy and inheritance
- **state-modules-example.dygram**: New comprehensive example (referenced in README but was missing)
- **Backward Compatible**: No breaking changes

Progresses #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)