### PR TITLE
feat: add subtle superscript view controls with text links

### DIFF
--- a/src/components/ExampleLoader.tsx
+++ b/src/components/ExampleLoader.tsx
@@ -88,6 +88,9 @@ export const ExampleLoader: React.FC<ExampleLoaderProps> = ({
         );
     }
 
+    // Extract filename from path
+    const filename = path.split('/').pop() || 'example';
+
     return (
         <CodeEditor
             initialCode={code}
@@ -95,6 +98,7 @@ export const ExampleLoader: React.FC<ExampleLoaderProps> = ({
             readOnly={readOnly}
             height={height}
             id={id}
+            filename={filename}
         />
     );
 };


### PR DESCRIPTION
## Summary

Enhances CodeEditor and ExampleLoader with subtle superscript text link controls for view toggling.

## Features
- Superscript header showing filename
- Text link toggles for view mode: Source | Diagram | Both
- Layout toggle: Vertical | Horizontal (desktop only, when both views shown)
- Responsive design that adapts to mobile/desktop
- No buttons, no overlap, subtle and non-intrusive
- Active state indicated by bold text
- Works with readOnly mode

Fixes #175

---
Generated with [Claude Code](https://claude.ai/code)