### PR TITLE
feat: add root-level machine attributes support

### DIFF
--- a/docs/examples/model-configuration.md
+++ b/docs/examples/model-configuration.md
@@ -66,10 +66,8 @@ Cost-Optimized System
 machine "Cost-Optimized System"
 
 // Machine-level configuration using haiku for all tasks (unless overridden)
-config {
-    modelId: "claude-3-5-haiku-20241022";
-    desc: "Use haiku by default for cost optimization";
-};
+modelId: "claude-3-5-haiku-20241022";
+description: "Use haiku by default for cost optimization";
 
 state start;
 

--- a/docs/guides/syntax-guide.md
+++ b/docs/guides/syntax-guide.md
@@ -13,6 +13,34 @@ machine "Machine Title"
 
 [Example: examples/basic/minimal.dygram](../examples/basic/minimal.dygram)
 
+### Machine-Level Attributes
+
+Machine-level attributes can be declared at the root level to configure the entire machine. These attributes use the `:` syntax and can appear anywhere at the root level:
+
+```dygram
+machine "Production System"
+
+modelId: "claude-4-sonnet-latest";
+title: "Alternative to base case";
+description: "Longer text can be provided to inform viewer";
+strictMode: true;
+
+Init start;
+end;
+
+start -"proceeds to"-> end;
+```
+
+**Common Machine Attributes:**
+- `title<string>` - Machine title (alternative to `machine "title"` syntax)
+- `modelId<string>` - Default LLM model for all tasks
+- `description<string>` - Detailed machine description
+- `strictMode<boolean>` - Enable strict validation mode
+- `version<string>` - Machine version
+- Custom attributes - Any custom machine-level configuration
+
+Machine attributes are distinguished from nodes by the `:` syntax - nodes use `{` or `;` instead.
+
 ## Node Declarations
 
 ### Untyped Nodes
@@ -166,6 +194,11 @@ Combining all features:
 
 ```dygram
 machine "Complete Example"
+
+// Machine-level configuration
+modelId: "claude-4-sonnet-latest";
+version: "1.0.0";
+description: "Production workflow with recovery";
 
 context config {
     env<string>: "production";

--- a/examples/model-configuration/machine-level-model.dygram
+++ b/examples/model-configuration/machine-level-model.dygram
@@ -1,10 +1,8 @@
 machine "Cost-Optimized System"
 
 // Machine-level configuration using haiku for all tasks (unless overridden)
-config {
-    modelId: "claude-3-5-haiku-20241022";
-    desc: "Use haiku by default for cost optimization";
-};
+modelId: "claude-3-5-haiku-20241022";
+description: "Use haiku by default for cost optimization";
 
 state start;
 

--- a/src/language/diagram/graphviz-dot-diagram.ts
+++ b/src/language/diagram/graphviz-dot-diagram.ts
@@ -139,6 +139,13 @@ export function generateDotDiagram(machineJson: MachineJSON, options: DiagramOpt
     lines.push('  edge [fontname="Arial", fontsize=9];');
     lines.push('');
 
+    // Machine attributes (if present) - displayed as a special node below the title
+    if (machineJson.attributes && machineJson.attributes.length > 0) {
+        lines.push('  // Machine Attributes');
+        lines.push(generateMachineAttributesNode(machineJson.attributes));
+        lines.push('');
+    }
+
     // Build semantic hierarchy based on parent-child relationships
     const hierarchy = buildSemanticHierarchy(machineJson.nodes);
     const rootNodes = getRootNodes(machineJson.nodes);
@@ -307,6 +314,49 @@ export function generateRuntimeDotDiagram(
     lines.push('}');
 
     return lines.join('\n');
+}
+
+/**
+ * Generate a special node for displaying machine attributes
+ * Styled with transparent/white borders similar to leaf nodes but distinguished
+ */
+function generateMachineAttributesNode(attributes: any[]): string {
+    // Build HTML label for machine attributes
+    let htmlLabel = '<table border="0" cellborder="0" cellspacing="0" cellpadding="4">';
+
+    // Header row
+    htmlLabel += '<tr><td align="left">';
+    htmlLabel += '<b>Machine</b> <i>&lt;Attributes&gt;</i>';
+    htmlLabel += '</td></tr>';
+
+    // Attributes table
+    if (attributes.length > 0) {
+        htmlLabel += '<tr><td>';
+        htmlLabel += '<table border="0" cellborder="1" cellspacing="0" cellpadding="2">';
+
+        attributes.forEach((attr: any) => {
+            let displayValue = attr.value;
+            if (typeof displayValue === 'string') {
+                displayValue = displayValue.replace(/^["']|["']$/g, '');
+                // Break long values into multiple lines
+                displayValue = breakLongText(displayValue, 30).join('<br/>');
+            }
+            const typeStr = attr.type ? ' : ' + escapeHtml(attr.type) : '';
+
+            htmlLabel += '<tr>';
+            htmlLabel += '<td align="left">' + escapeHtml(attr.name) + typeStr + '</td>';
+            htmlLabel += '<td align="left">' + escapeHtml(String(displayValue)) + '</td>';
+            htmlLabel += '</tr>';
+        });
+
+        htmlLabel += '</table>';
+        htmlLabel += '</td></tr>';
+    }
+
+    htmlLabel += '</table>';
+
+    // Style with white/transparent borders (similar to leaf nodes but lighter)
+    return `  "MachineAttributes" [label=<${htmlLabel}>, shape=box, fillcolor="#FAFAFA", style=filled, color="#E0E0E0", penwidth=1];`;
 }
 
 /**

--- a/src/language/diagram/mermaid-class-diagram.ts
+++ b/src/language/diagram/mermaid-class-diagram.ts
@@ -77,6 +77,12 @@ export function generateClassDiagram(machineJson: MachineJSON, options: MermaidO
     lines.push('classDiagram-v2');
     lines.push('');
 
+    // Machine attributes (if present) - displayed as a special class below the title
+    if (machineJson.attributes && machineJson.attributes.length > 0) {
+        lines.push(generateMachineAttributesClass(machineJson.attributes));
+        lines.push('');
+    }
+
     // Build semantic hierarchy based on parent-child relationships
     const hierarchy = buildSemanticHierarchy(machineJson.nodes);
     const rootNodes = getRootNodes(machineJson.nodes);
@@ -306,6 +312,38 @@ function buildSemanticHierarchy(nodes: any[]): SemanticHierarchy {
  */
 function getRootNodes(nodes: any[]): any[] {
     return nodes.filter(node => !node.parent);
+}
+
+/**
+ * Generate a special class for displaying machine attributes
+ * Styled with transparent borders to distinguish from regular nodes
+ */
+function generateMachineAttributesClass(attributes: any[]): string {
+    const lines: string[] = [];
+
+    // Create a special class for machine attributes
+    lines.push('  class MachineAttributes {');
+    lines.push('    <<Machine>>');
+
+    // Add each attribute with type and value
+    attributes.forEach(attr => {
+        let displayValue = attr.value;
+        if (typeof displayValue === 'string') {
+            displayValue = displayValue.replace(/^["']|["']$/g, '');
+            displayValue = wrapText(displayValue, 60);
+        }
+
+        const typeStr = attr.type ? convertTypeToMermaid(String(attr.type)) : '';
+        lines.push(`    +${attr.name}${typeStr ? ` : ${typeStr}` : ''} = ${displayValue}`);
+    });
+
+    lines.push('  }');
+
+    // Apply special styling for machine attributes (white/transparent borders)
+    lines.push('  classDef machineAttributesStyle fill:#FAFAFA,stroke:#E0E0E0,stroke-width:1px,stroke-dasharray: 5 5');
+    lines.push('  class MachineAttributes machineAttributesStyle');
+
+    return lines.join('\n');
 }
 
 /**

--- a/src/language/diagram/types.ts
+++ b/src/language/diagram/types.ts
@@ -11,6 +11,7 @@
  */
 export interface MachineJSON {
     title?: string;
+    attributes?: Array<{ name: string; type?: string; value: any }>; // Machine-level attributes
     nodes: any[]; // Flexible to accept both Node[] from AST and simplified runtime nodes
     edges: any[]; // Flexible to accept both Edge[] from AST and simplified runtime edges
     notes?: any[];

--- a/src/language/machine-module.ts
+++ b/src/language/machine-module.ts
@@ -44,8 +44,15 @@ export interface InferredDependency {
     path: string;
 }
 
+export interface MachineAttribute {
+    name: string;
+    type?: string;
+    value: any;
+}
+
 export interface MachineJSON {
     title?: string;
+    attributes?: MachineAttribute[];
     nodes: Node[];
     edges: Edge[];
     notes?: NoteInfo[];

--- a/src/language/machine.langium
+++ b/src/language/machine.langium
@@ -54,7 +54,13 @@ QualifiedName returns string:
 
 entry Machine:
     ('machine' title=STRING ';'?)?
-    (nodes+=Node<true> | edges+=Edge<true> | notes+=Note)* 
+    (machineAttributes+=MachineAttribute | nodes+=Node<true> | edges+=Edge<true> | notes+=Note)*
+;
+
+// Machine-level attributes at root level (e.g., modelId: "...", title: "...", strictMode: true)
+// Distinguished from nodes by the presence of ':' after the name
+MachineAttribute:
+    name=ID ('<' type=TypeDef '>')? ':' value=AttributeValue ';'?
 ;
 
 // Note: Using '=' for single values and '+=' for arrays is intentional.


### PR DESCRIPTION
## Summary

Implements root-level machine attributes with "frontmatter anywhere" pattern as requested in #191.

## Changes

- ✅ Added `MachineAttribute` grammar rule with `:` syntax
- ✅ Support attributes anywhere at root level (modelId:, title:, description:, etc.)
- ✅ Distinguished from nodes by presence of colon
- ✅ Updated documentation and examples
- ✅ `config` node remains normal context behavior (no special handling)

## Example

```dygram
machine "My System"

modelId: "claude-4-sonnet-latest";
description: "System description";

Init start;
```

Closes #191

🤖 Generated with [Claude Code](https://claude.ai/code)