### PR TITLE
fix: visualize namespace attributes in graphviz diagrams

### DIFF
--- a/src/language/diagram/graphviz-dot-diagram.ts
+++ b/src/language/diagram/graphviz-dot-diagram.ts
@@ -364,7 +364,15 @@ function generateSemanticHierarchy(
             lines.push(`${indent}  color="#999999";`);
             lines.push('');
 
-            
+            // Add representative node for parent if it has attributes, type, or annotations
+            const hasAttributes = node.attributes && node.attributes.length > 0;
+            const hasType = node.type && node.type.length > 0;
+            const hasAnnotations = node.annotations && node.annotations.length > 0;
+
+            if (hasAttributes || hasType || hasAnnotations) {
+                lines.push(generateNodeDefinition(node, edges, indent + '  '));
+                lines.push('');
+            }
 
             // Recursively generate children
             const childNodes = children.map(childName => hierarchy[childName].node);


### PR DESCRIPTION
## Summary

Fixed issue where nested nodes (namespaces) with attributes were not displaying their attributes, type, or annotations in graphviz DOT output.

## Changes

- Modified `generateSemanticHierarchy` function in `src/language/diagram/graphviz-dot-diagram.ts`
- Added logic to render representative node inside clusters when parent has attributes/type/annotations
- Maintains consistency with leaf node rendering

## Testing

- Build succeeded
- Manual testing confirmed namespace attributes now display correctly
- Existing test suite passes (no new failures)

Resolves #192

Generated with [Claude Code](https://claude.ai/code)