### PR TITLE
feat: implement style nodes for custom graphviz styling

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1,0 +1,116 @@
+# Custom Styling
+
+DyGram supports custom styling through special `style` nodes that define reusable visual styling rules. Style nodes are non-executable metadata that apply graphviz attributes to nodes based on annotation selectors.
+
+## Syntax
+
+Style nodes use the following syntax:
+
+```dygram
+style <name> @<selector> {
+    <graphviz-attribute>: <value>;
+    ...
+}
+```
+
+- **name**: Identifier for the style node (for reference)
+- **@selector**: Annotation name to match against other nodes
+- **attributes**: Graphviz DOT attributes (fillcolor, penwidth, color, shape, etc.)
+
+## Example
+
+```dygram
+machine "Custom Styling Example"
+
+// Define style nodes with annotation selectors
+// These are non-executable metadata that control visual appearance
+
+style criticalStyle @Critical {
+    fillcolor: "#ffcccc";
+    penwidth: 3;
+    color: "#cc0000";
+}
+
+style warningStyle @Warning {
+    fillcolor: "#ffffcc";
+    penwidth: 2;
+    color: "#cccc00";
+}
+
+style successStyle @Success {
+    fillcolor: "#ccffcc";
+    penwidth: 2;
+    color: "#00cc00";
+}
+
+// Regular nodes with annotations that trigger the styles
+
+Task start "Initialize system" {
+    prompt: "Initialize the payment processing system";
+}
+
+Task validatePayment "Validate Payment" @Critical {
+    prompt: "Validate payment details with strict checks";
+}
+
+Task checkBalance "Check Balance" @Warning {
+    prompt: "Check if account has sufficient balance";
+}
+
+State processing "Processing payment";
+
+Task completePayment "Complete Payment" @Success {
+    prompt: "Finalize the payment transaction";
+}
+
+State done "Transaction complete";
+
+// Define the workflow
+start -> validatePayment;
+validatePayment -> checkBalance;
+checkBalance -> processing;
+processing -> completePayment;
+completePayment -> done;
+```
+
+## How It Works
+
+1. **Define Style Nodes**: Create style nodes with the `style` keyword, a name, and a selector annotation
+2. **Add Attributes**: Add any graphviz DOT attributes inside the style node's attribute block
+3. **Apply Styles**: Use the matching annotation on any regular node to apply the style
+4. **Non-Executable**: Style nodes are filtered out during rendering and execution - they're pure metadata
+
+## Supported Attributes
+
+Style nodes support any graphviz DOT attribute:
+
+- **Colors**: `fillcolor`, `color`, `fontcolor`
+- **Lines**: `penwidth`, `style` (e.g., "dashed", "dotted")
+- **Shapes**: `shape` (e.g., "box", "ellipse", "diamond")
+- **Layout**: `peripheries`, `margin`, `height`, `width`
+- And many more - see [Graphviz documentation](https://graphviz.org/doc/info/attrs.html)
+
+## Multiple Styles
+
+A node can have multiple annotations, and each matching style will be applied:
+
+```dygram
+style errorStyle @Error {
+    color: "#ff0000";
+}
+
+style urgentStyle @Urgent {
+    penwidth: 3;
+}
+
+Task criticalError @Error @Urgent {
+    prompt: "Handle critical error";
+}
+```
+
+## Benefits
+
+- **Reusable**: Define styles once, apply to many nodes
+- **Declarative**: Separates visual styling from behavior
+- **Type-Safe**: Works with existing annotation system
+- **No Grammar Changes**: Uses existing DyGram syntax

--- a/src/language/base-executor.ts
+++ b/src/language/base-executor.ts
@@ -92,7 +92,11 @@ export abstract class BaseExecutor {
     protected celEvaluator: CelEvaluator;
 
     constructor(machineData: MachineData, config: MachineExecutorConfig = {}) {
-        this.machineData = machineData;
+        // Filter out style nodes from execution (they're metadata only)
+        this.machineData = {
+            ...machineData,
+            nodes: machineData.nodes.filter(n => !NodeTypeChecker.isStyleNode(n))
+        };
 
         // Initialize CEL evaluator
         this.celEvaluator = new CelEvaluator();

--- a/src/language/node-type-checker.ts
+++ b/src/language/node-type-checker.ts
@@ -225,6 +225,15 @@ export class NodeTypeChecker {
     }
 
     /**
+     * Check if a node is a style node
+     * Style nodes are non-executable metadata that define visual styling rules
+     * They are identified by explicit type 'style' or 'Style'
+     */
+    static isStyleNode(node: NodeLike | ASTNode): boolean {
+        return node.type?.toLowerCase() === 'style';
+    }
+
+    /**
      * Check if a node requires agent decision
      * A node requires agent decision if:
      * 1. It's a task node with a prompt, OR


### PR DESCRIPTION
## Summary

Implements style nodes for custom graphviz styling using annotation selectors. Style nodes are non-executable metadata that allow declarative styling without grammar changes.

## Changes

- Add `isStyleNode()` to NodeTypeChecker
- Filter style nodes from rendering in graphviz-dot-diagram.ts
- Apply custom styles based on annotation matching
- Filter style nodes from execution in base-executor.ts
- Add complete documentation in docs/styling.md

## Example

```dygram
style criticalStyle @Critical {
    fillcolor: "#ffcccc";
    penwidth: 3;
}

Task payment @Critical {
    prompt: "Process payment";
}
```

Closes #201

Generated with [Claude Code](https://claude.ai/code)