### PR TITLE
fix: add annotations field to Edge interface

### DIFF
--- a/src/language/machine-module.ts
+++ b/src/language/machine-module.ts
@@ -23,6 +23,7 @@ export interface Edge {
     arrowType?: string;  // Arrow type for relationship mapping
     sourceMultiplicity?: string;  // Source multiplicity (e.g., "1", "*", "0..1")
     targetMultiplicity?: string;  // Target multiplicity (e.g., "1", "*", "1..*")
+    annotations?: Array<{ name: string; value?: string }>;  // Edge annotations
     style?: EdgeStyle;  // Custom styling for the edge
     roleName?: string;  // Role name for bidirectional relationships
 }


### PR DESCRIPTION
Fixes type-checking issue from PR #213

## Summary

Adds the missing `annotations` field to the `Edge` interface, resolving the type-checking error identified by Codex where `edge.annotations` was used but not defined.

## Changes

- Add optional `annotations` field to Edge interface in machine-module.ts
- Field type matches structure returned by `serializeEdgeAnnotations()`

🤖 Generated with [Claude Code](https://claude.ai/code)