### PR TITLE
feat: add template interpolation to runtime diagrams

### DIFF
--- a/src/language/diagram/graphviz-generator.ts
+++ b/src/language/diagram/graphviz-generator.ts
@@ -85,6 +85,7 @@ export function generateRuntimeGraphviz(
         showVisitCounts: true,
         showExecutionPath: true,
         showRuntimeValues: true,
+        runtimeContext: context, // Pass context for template interpolation
         ...options
     };
 

--- a/src/language/diagram/types.ts
+++ b/src/language/diagram/types.ts
@@ -48,6 +48,9 @@ export interface DiagramOptions {
     /** Custom title override */
     title?: string;
 
+    /** Runtime context for template interpolation */
+    runtimeContext?: RuntimeContext;
+
     /** Validation context with warnings to visualize */
     validationContext?: any; // Import would create circular dependency, use any for now
 


### PR DESCRIPTION
Add template interpolation functionality that resolves {{ variable }} patterns in runtime diagrams using CEL evaluator. This allows diagrams to show actual interpolated values instead of raw template syntax.

Changes:
- Add interpolateValue() helper function using CEL evaluator
- Update diagram generation to interpolate templates in runtime context
- Add runtimeContext field to DiagramOptions for passing context
- Interpolate templates in machine labels, namespace labels, node definitions, and attributes
- Runtime diagrams now show actual values instead of template syntax
- Static diagrams continue to show template syntax as-is

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)