### PR TITLE
fix: ensure build runs even when tests fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "test:e2e:headed": "playwright test --headed",
         "test:all": "npm run test && npm run test:runtime && npm run test:e2e",
         "test:reports": "npm run test && npm run test:e2e && node scripts/generate-test-index.js",
-        "build:with-tests": "npm run test:reports && npm run build"
+        "build:with-tests": "npm run test:reports || true && npm run build"
     },
     "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.14",


### PR DESCRIPTION
Fixes #234

Modified the `build:with-tests` script to use `|| true` so that test failures don't prevent the build step from running. This ensures test reports and build artifacts are always generated.

## Changes
- Updated package.json script: `build:with-tests`

Generated with [Claude Code](https://claude.ai/code)