### PR TITLE
Fix collapsed playground flex behavior

### DIFF
--- a/src/components/CodeMirrorPlayground.tsx
+++ b/src/components/CodeMirrorPlayground.tsx
@@ -212,7 +212,7 @@ const MainContainer = styled.div`
 `;
 
 const EditorSection = styled.div<{ $collapsed?: boolean }>`
-    flex: ${props => props.$collapsed ? '0 0 auto' : '1 1 0'};
+    flex: ${props => props.$collapsed ? '0 0 0' : '1 1 0'};
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -226,7 +226,7 @@ const EditorSection = styled.div<{ $collapsed?: boolean }>`
 `;
 
 const SectionContent = styled.div<{ $collapsed?: boolean }>`
-    flex: ${props => props.$collapsed ? '0 0 auto' : '1 1 0'};
+    flex: ${props => props.$collapsed ? '0 0 0' : '1 1 0'};
     overflow: ${props => props.$collapsed ? 'hidden' : 'auto'};
     transition: flex 0.3s ease;
     min-height: 0;
@@ -269,7 +269,7 @@ const EditorContainer = styled.div`
 `;
 
 const OutputSection = styled.div<{ $collapsed?: boolean }>`
-    flex: ${props => props.$collapsed ? '0 0 auto' : '1 1 0'};
+    flex: ${props => props.$collapsed ? '0 0 0' : '1 1 0'};
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -288,8 +288,13 @@ const ExecutionSection = styled.div<{ $collapsed?: boolean }>`
     transition: flex 0.3s ease;
     max-height: ${props => props.$collapsed ? '0' : '400px'};
     height: ${props => props.$collapsed ? '0' : 'auto'};
-    flex: ${props => props.$collapsed ? '0 0 auto' : '1 1 auto'};
+    flex: ${props => props.$collapsed ? '0 0 0' : '1 1 auto'};
     min-height: 0;
+`;
+
+const ExecutionContainer = styled.div`
+    display: flex;
+    flex-direction: column;
 `;
 
 // Main Component
@@ -769,23 +774,24 @@ start -> end;`;
                 </OutputSection>
             </MainContainer>
 
-            <SectionHeader onClick={toggleExecution}>
+            <ExecutionContainer>
+                <SectionHeader onClick={toggleExecution}>
                     <span>Execution</span>
                     <ToggleBtn>{executionCollapsed ? '▶' : '▼'}</ToggleBtn>
                 </SectionHeader>
-            <ExecutionSection $collapsed={executionCollapsed}>
-                
-                <SectionContent $collapsed={executionCollapsed}>
-                    <ExecutionControls
-                        onExecute={handleExecute}
-                        onStep={handleStep}
-                        onStop={handleStop}
-                        onReset={handleReset}
-                        mobile={false}
-                        showLog={true}
-                    />
-                </SectionContent>
-            </ExecutionSection>
+                <ExecutionSection $collapsed={executionCollapsed}>
+                    <SectionContent $collapsed={executionCollapsed}>
+                        <ExecutionControls
+                            onExecute={handleExecute}
+                            onStep={handleStep}
+                            onStop={handleStop}
+                            onReset={handleReset}
+                            mobile={false}
+                            showLog={true}
+                        />
+                    </SectionContent>
+                </ExecutionSection>
+            </ExecutionContainer>
         </Container>
     );
 };


### PR DESCRIPTION
## Summary
- adjust section containers in the CodeMirror playground to flex and shrink correctly when collapsed by giving collapsed panels a zero flex-basis
- ensure scrollable content fills available space by enforcing min-height and flex rules
- keep the execution section header outside the collapsing panel so its toggle stays visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fb3a185280832e8b5080f9a1d5d892