### PR TITLE
fix: resolve attribute-qualified edge endpoints

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -73,6 +73,47 @@ processing -> completePayment;
 completePayment -> done;
 ```
 
+## Advanced Example: Refined Styling, Ports, and Layout
+
+The following example combines reusable style metadata, nested namespaces, and
+attribute-level ports. Style nodes remain metadata only—they never appear in the
+rendered diagram—but any node or edge annotated with the matching selector will
+inherit the declared Graphviz attributes.
+
+```dygram
+machine "Refined styling, ports, and layout"
+description: "my machine description"
+type: "example"
+
+parent {
+    spouse: "Alice";
+    child1 @highlight {
+        age: 38;
+        grandchild {
+            age: 7;
+        }
+    }
+    child2 @highlight {
+        likes: apples; // node IDs can be used as attribute values
+    }
+}
+
+apples;
+
+// Style metadata only – applies to any node or edge annotated with @highlight
+style highlightStyle @highlight {
+    color: red;
+    rank: "group:one"; // supports rank aliases such as group:/align:/same:
+    shape: "star";
+}
+
+parent.spouse -"begets..."-> parent.child1;
+child1 -@highlight @style("color: yellow; gradientangle: 90")-> child2;
+
+// Inferred edge from attribute reference
+child2.likes -likes-> apples;
+```
+
 ## How It Works
 
 1. **Define Style Nodes**: Create style nodes with the `style` keyword, a name, and a selector annotation

--- a/src/language/diagram/graphviz-dot-diagram.ts
+++ b/src/language/diagram/graphviz-dot-diagram.ts
@@ -1455,8 +1455,13 @@ function generateEdges(machineJson: MachineJSON, styleNodes: any[] = [], wrappin
         let sourcePortName: string | undefined;
         let targetPortName: string | undefined;
 
-        const useSourceClusterAnchor = sourceIsParent || ((sourcePortHandle === 'cluster' || sourcePortHandle === 'header') && parentNodes.has(edge.source));
-        const useTargetClusterAnchor = targetIsParent || ((targetPortHandle === 'cluster' || targetPortHandle === 'header') && parentNodes.has(edge.target));
+        const hasExplicitSourceAttribute = Boolean(sourceAttributeHandle);
+        const hasExplicitTargetAttribute = Boolean(targetAttributeHandle);
+
+        const useSourceClusterAnchor = (sourceIsParent && !hasExplicitSourceAttribute && !sourcePortHandle)
+            || ((sourcePortHandle === 'cluster' || sourcePortHandle === 'header') && parentNodes.has(edge.source));
+        const useTargetClusterAnchor = (targetIsParent && !hasExplicitTargetAttribute && !targetPortHandle)
+            || ((targetPortHandle === 'cluster' || targetPortHandle === 'header') && parentNodes.has(edge.target));
 
         if (useSourceClusterAnchor) {
             actualSource = getClusterAnchorName(edge.source);

--- a/src/language/machine.langium
+++ b/src/language/machine.langium
@@ -79,7 +79,11 @@ ArrayValue:
 
 // Primitive value: string, number, ID, or external ID
 PrimitiveValue:
-    value=(EXTID|STRING|ID|NUMBER)
+    value=(EXTID|STRING|QualifiedIdentifier|ID|NUMBER)
+;
+
+QualifiedIdentifier returns string:
+    ID '.' ID ('.' ID)*
 ;
 
 // Annotation for nodes (e.g., @Abstract, @Singleton, @Deprecated, @note)

--- a/src/language/utils/reference-utils.ts
+++ b/src/language/utils/reference-utils.ts
@@ -1,0 +1,137 @@
+import type { Machine, Node } from '../generated/ast.js';
+
+export interface ResolvedReference {
+    node?: Node;
+    attribute?: string;
+}
+
+const QUALIFIED_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
+function sanitizeQualified(value: string): string {
+    return value.replace(/^["']|["']$/g, '').trim();
+}
+
+export function splitQualifiedPath(value: string | undefined): string[] {
+    if (!value) {
+        return [];
+    }
+
+    const sanitized = sanitizeQualified(value);
+    if (!sanitized) {
+        return [];
+    }
+
+    return sanitized.split('.').map(segment => segment.trim()).filter(Boolean);
+}
+
+export function isPotentialQualifiedReference(value: string | undefined): boolean {
+    if (!value) {
+        return false;
+    }
+
+    const sanitized = sanitizeQualified(value);
+    if (!sanitized) {
+        return false;
+    }
+
+    return QUALIFIED_IDENTIFIER_PATTERN.test(sanitized);
+}
+
+export function resolveQualifiedPath(machine: Machine, qualified: string | undefined): ResolvedReference {
+    if (!qualified) {
+        return { node: undefined, attribute: undefined };
+    }
+
+    const segments = splitQualifiedPath(qualified);
+    if (segments.length === 0) {
+        return { node: undefined, attribute: undefined };
+    }
+
+    let current: Node | undefined;
+    let children: Node[] = machine.nodes;
+
+    for (let index = 0; index < segments.length; index++) {
+        const segment = segments[index];
+        const next = children.find(child => child.name === segment);
+
+        if (next) {
+            current = next;
+            children = next.nodes ?? [];
+            continue;
+        }
+
+        if (current && index === segments.length - 1) {
+            const hasAttribute = current.attributes?.some(attr => attr.name === segment);
+            if (hasAttribute) {
+                return { node: current, attribute: segment };
+            }
+        }
+
+        current = undefined;
+        break;
+    }
+
+    if (current) {
+        return { node: current, attribute: undefined };
+    }
+
+    if (segments.length >= 2) {
+        const attributeName = segments[segments.length - 1];
+        const nodeSegments = segments.slice(0, -1);
+
+        const resolvedNode = findNodeBySegments(machine, nodeSegments)
+            ?? findNodeByName(machine.nodes, nodeSegments[nodeSegments.length - 1]);
+
+        if (resolvedNode && resolvedNode.attributes?.some(attr => attr.name === attributeName)) {
+            return { node: resolvedNode, attribute: attributeName };
+        }
+    }
+
+    if (segments.length === 1) {
+        const node = findNodeByName(machine.nodes, segments[0]);
+        if (node) {
+            return { node, attribute: undefined };
+        }
+    }
+
+    return { node: undefined, attribute: undefined };
+}
+
+function findNodeByName(nodes: Node[], name: string | undefined): Node | undefined {
+    if (!name) {
+        return undefined;
+    }
+
+    for (const node of nodes) {
+        if (node.name === name) {
+            return node;
+        }
+
+        const child = findNodeByName(node.nodes ?? [], name);
+        if (child) {
+            return child;
+        }
+    }
+
+    return undefined;
+}
+
+export function findNodeBySegments(machine: Machine, segments: string[]): Node | undefined {
+    if (segments.length === 0) {
+        return undefined;
+    }
+
+    let current: Node | undefined;
+    let children: Node[] = machine.nodes;
+
+    for (const segment of segments) {
+        const next = children.find(child => child.name === segment);
+        if (!next) {
+            return undefined;
+        }
+        current = next;
+        children = next.nodes ?? [];
+    }
+
+    return current;
+}


### PR DESCRIPTION
## Summary
- allow qualified identifiers in attribute values and add reference resolution helpers shared by the linker, generator, and dependency analyzer
- capture attribute metadata when serializing edges so Graphviz output reuses attribute ports instead of creating placeholder nodes
- extend linking and integration tests to cover attribute-qualified references and validate DOT output for attribute endpoints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fc100c830c832e84956422521fc013