### PR TITLE
fix: exclude archived docs from example extraction

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -85,7 +85,7 @@ async function extractExamples(projectRoot) {
         for (const entry of entries) {
             const fullPath = join(dir, entry.name);
             if (entry.isDirectory()) {
-                if (entry.name !== 'node_modules' && entry.name !== '.git') {
+                if (entry.name !== 'node_modules' && entry.name !== '.git' && entry.name !== 'archived') {
                     files.push(...await scanMarkdownFiles(fullPath));
                 }
             } else if (entry.name.endsWith('.md') || entry.name.endsWith('.mdx')) {


### PR DESCRIPTION
## Summary
Updated prebuild script to exclude `./docs/archived/*` from example extraction and ran tests to verify no issues.

## Changes
- Added `archived` to excluded directories in `extractExamples` function
- Aligns with existing behavior in other prebuild steps
- All tests pass successfully

Fixes #272

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/christopherdebeer/machine/actions/runs/18820551654) | [View branch](https://github.com/christopherdebeer/machine/tree/claude/issue-272-20251026-1619