### PR TITLE
fix: correct annotation placement in homepage documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -269,7 +269,7 @@ Visualization <--> Generate;
 
 note Language "DyGram is a DSL for dynamic state machines that bridges conceptual thinking and structured implementation. It features rails-based execution where deterministic paths execute instantly while complex decisions leverage Claude's reasoning.";
 
-note Execute @Critical "The Execute task demonstrates meta-programming: agents ride machine rails, make intelligent decisions at branching points, and can construct tools dynamically during execution.";
+note Execute "The Execute task demonstrates meta-programming: agents ride machine rails, make intelligent decisions at branching points, and can construct tools dynamically during execution." @Critical;
 
 note config "Configuration context is inherited by all tasks through semantic nesting - no explicit edges needed. This showcases DyGram's automatic context propagation.";
 ```


### PR DESCRIPTION
## Summary
Fixed syntax error in homepage documentation where `@Critical` annotation was placed before the string instead of after it.

## Changes
- Moved `@Critical` annotation to correct position in docs/README.md line 272
- Per Langium grammar, annotations must come after title string: `note <name> "<title>" @Annotation;`

## Test Results
✅ Homepage example (uncategorised/Example 4) now parses without errors

Fixes #272

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/christopherdebeer/machine/actions/runs/18820663393) | [View branch](https://github.com/christopherdebeer/machine/tree/claude/issue-272-20251026-1628