### PR TITLE
Fix qualified node ID validation in strict mode

### DIFF
--- a/src/language/machine-validator.ts
+++ b/src/language/machine-validator.ts
@@ -4,7 +4,6 @@ import type { MachineServices } from './machine-module.js';
 import { TypeChecker } from './type-checker.js';
 import { GraphValidator } from './graph-validator.js';
 import { DependencyAnalyzer } from './dependency-analyzer.js';
-import { extractValueFromAST } from './utils/ast-helpers.js';
 
 /**
  * Registry for validation checks.
@@ -115,14 +114,22 @@ export class MachineValidator {
         }
 
         // Collect all explicitly defined node names (excluding notes)
+        // Include both simple names and qualified names for nested nodes
         const stateNames = new Set<string>();
-        const collectStateNames = (node: Node) => {
+        const collectStateNames = (node: Node, prefix: string = '') => {
             // Don't add note nodes themselves to the state names set
             if (node.type?.toLowerCase() !== 'note') {
+                // Add simple name
                 stateNames.add(node.name);
+                // Add qualified name if nested
+                if (prefix) {
+                    stateNames.add(`${prefix}.${node.name}`);
+                }
             }
+            // Recursively collect child nodes with qualified path
+            const newPrefix = prefix ? `${prefix}.${node.name}` : node.name;
             for (const childNode of node.nodes) {
-                collectStateNames(childNode);
+                collectStateNames(childNode, newPrefix);
             }
         };
 

--- a/test-issue-287.dygram
+++ b/test-issue-287.dygram
@@ -1,0 +1,60 @@
+machine "Comprehensive Demo" @StrictMode @Version("1.0")
+
+// Machine-level configuration
+Context config {
+    model: "claude-3-5-sonnet-20241022";
+    temperature: 0.7;
+    endpoints<Array<string>>: ["api1.com", "api2.com"];
+};
+
+// Input with schema reference
+Input userRequest {
+    query: "Sample query";
+    schema: #requestSchema;
+};
+
+// Nested process with hierarchy
+Process analysis {
+    Task preprocess "Clean data" @Async {
+        priority<number>: 10;
+        timeout: "30s";
+    };
+
+    Task analyze "Analyze content" {
+        prompt: "Analyze: {{ userRequest.query }}";
+        model: "claude-3-5-sonnet-20241022";
+    };
+
+    State processing "Processing State";
+
+    preprocess -> analyze -> processing;
+};
+
+// Parallel processing
+Task taskA "Path A" @Async;
+Task taskB "Path B" @Async;
+Task merge "Merge Results";
+
+// Output node
+Output result {
+    status: "pending";
+    data: #outputData;
+};
+
+// Complex edges with different arrow types
+userRequest -> analysis;
+analysis.processing -> taskA, taskB;
+taskA -> merge;
+taskB -> merge;
+merge => result;
+
+// Relationship arrows
+Task parent;
+Task child;
+child <|-- parent;  // Inheritance
+
+// Documentation
+note analysis "This process handles the main analysis pipeline" @Documentation {
+    complexity: "O(n)";
+    author: "System";
+};

--- a/test/validating/qualified-node-id.test.ts
+++ b/test/validating/qualified-node-id.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test, beforeAll } from 'vitest';
+import { EmptyFileSystem } from 'langium';
+import { parseHelper } from 'langium/test';
+import { createMachineServices } from '../../src/language/machine-module.js';
+import { Machine } from '../../src/language/generated/ast.js';
+
+describe('Qualified Node ID Validation', () => {
+    let parse: ReturnType<typeof parseHelper<Machine>>;
+
+    beforeAll(() => {
+        const services = createMachineServices(EmptyFileSystem);
+        const doParse = parseHelper<Machine>(services.Machine);
+        parse = (input: string) => doParse(input, { validation: true });
+    });
+
+    test('should recognize qualified node IDs in strict mode', async () => {
+        const document = await parse(`
+            machine "Test" @StrictMode
+
+            Process analysis {
+                State processing "Processing State";
+            };
+
+            Task taskA "Task A";
+
+            // This should not error - analysis.processing is defined
+            analysis.processing -> taskA;
+        `);
+
+        expect(document).toBeDefined();
+        const errors = (document.diagnostics || []).filter(d => d.severity === 1); // 1 = Error
+
+        // Should have NO errors
+        expect(errors.length).toBe(0);
+    });
+
+    test('should recognize multiple levels of nesting', async () => {
+        const document = await parse(`
+            machine "Test" @StrictMode
+
+            Process workflow {
+                Process analysis {
+                    State processing "Processing";
+                };
+            };
+
+            Task taskA "Task A";
+
+            // Should recognize workflow.analysis.processing
+            workflow.analysis.processing -> taskA;
+        `);
+
+        expect(document).toBeDefined();
+        const errors = (document.diagnostics || []).filter(d => d.severity === 1);
+
+        // Should have NO errors
+        expect(errors.length).toBe(0);
+    });
+
+    test('should still catch truly undefined qualified references', async () => {
+        const document = await parse(`
+            machine "Test" @StrictMode
+
+            Process analysis {
+                State processing "Processing State";
+            };
+
+            Task taskA "Task A";
+
+            // This SHOULD error - analysis.undefined is not defined
+            analysis.undefined -> taskA;
+        `);
+
+        expect(document).toBeDefined();
+        const errors = (document.diagnostics || []).filter(d => d.severity === 1);
+
+        // Should have errors for undefined reference
+        expect(errors.length).toBeGreaterThan(0);
+        expect(errors.some(e => e.message.includes('undefined'))).toBe(true);
+    });
+
+    test('should work with the comprehensive demo from issue #287', async () => {
+        const document = await parse(`
+            machine "Comprehensive Demo" @StrictMode @Version("1.0")
+
+            // Machine-level configuration
+            Context config {
+                model: "claude-3-5-sonnet-20241022";
+                temperature: 0.7;
+                endpoints<Array<string>>: ["api1.com", "api2.com"];
+            };
+
+            // Input with schema reference
+            Input userRequest {
+                query: "Sample query";
+                schema: #requestSchema;
+            };
+
+            // Nested process with hierarchy
+            Process analysis {
+                Task preprocess "Clean data" @Async {
+                    priority<number>: 10;
+                    timeout: "30s";
+                };
+
+                Task analyze "Analyze content" {
+                    prompt: "Analyze: {{ userRequest.query }}";
+                    model: "claude-3-5-sonnet-20241022";
+                };
+
+                State processing "Processing State";
+
+                preprocess -> analyze -> processing;
+            };
+
+            // Parallel processing
+            Task taskA "Path A" @Async;
+            Task taskB "Path B" @Async;
+            Task merge "Merge Results";
+
+            // Output node
+            Output result {
+                status: "pending";
+                data: #outputData;
+            };
+
+            // Complex edges with different arrow types
+            userRequest -> analysis;
+            analysis.processing -> taskA, taskB;
+            taskA -> merge;
+            taskB -> merge;
+            merge => result;
+
+            // Relationship arrows
+            Task parent;
+            Task child;
+            child <|-- parent;  // Inheritance
+
+            // Documentation
+            note analysis "This process handles the main analysis pipeline" @Documentation {
+                complexity: "O(n)";
+                author: "System";
+            };
+        `);
+
+        expect(document).toBeDefined();
+        const errors = (document.diagnostics || []).filter(d => d.severity === 1);
+
+        // Should have NO errors - analysis.processing is properly defined
+        expect(errors.length).toBe(0);
+    });
+});


### PR DESCRIPTION
Fixes #287

## Summary
Fixed the qualified node ID validation issue where nested node references like `analysis.processing` were incorrectly flagged as undefined in strict mode.

## Changes
- Updated `checkInvalidStateReferences` to collect both simple and qualified names
- The validator now properly recognizes nested node references
- Added comprehensive test suite for qualified node ID validation

## Test Results
All new tests pass, including:
- Simple qualified IDs (e.g., `analysis.processing`)
- Multiple levels of nesting (e.g., `workflow.analysis.processing`)
- Still catches truly undefined references
- The comprehensive demo from the issue now validates without errors

Generated with [Claude Code](https://claude.ai/code)