### PR TITLE
fix: preserve note attributes in backward compilation

### DIFF
--- a/src/language/generator/generator.ts
+++ b/src/language/generator/generator.ts
@@ -2058,17 +2058,31 @@ function generateNoteDSL(note: any): string {
     }
 
     // Add annotations if present
+    let annotationsStr = '';
     if (note.annotations && note.annotations.length > 0) {
-        const annotationsStr = note.annotations.map((ann: any) => {
+        annotationsStr = note.annotations.map((ann: any) => {
             if (ann.value) {
                 return ` @${ann.name}(${quoteString(ann.value)})`;
             }
             return ` @${ann.name}`;
         }).join('');
-        return parts.join(' ') + annotationsStr + ';';
     }
 
-    return parts.join(' ') + ';';
+    // Check if note has attributes
+    const hasAttributes = note.attributes && note.attributes.length > 0;
+
+    if (hasAttributes) {
+        // Note with attributes - use block syntax
+        let result = parts.join(' ') + annotationsStr + ' {\n';
+        note.attributes.forEach((attr: any) => {
+            result += '    ' + generateAttributeDSL(attr) + '\n';
+        });
+        result += '}';
+        return result;
+    } else {
+        // Simple note - use inline syntax
+        return parts.join(' ') + annotationsStr + ';';
+    }
 }
 
 function formatValue(value: any): string {


### PR DESCRIPTION
Fixes the issue identified by Codex in PR #296 where note attributes were not preserved during backward compilation.

## Changes
- Modified `generateNoteDSL()` to check for attributes and use block syntax
- Follows same pattern as `generateNodeDSL()` for consistency
- Ensures notes with attributes survive round-trip conversion

## Testing
- All backward compilation tests pass
- Overall test suite maintains 97.3% pass rate

Addresses Codex P1 feedback on #296

Generated with [Claude Code](https://claude.ai/code)