### PR TITLE
fix: use shared URL encoding utility in test reports

### DIFF
--- a/test/integration/comprehensive-generative.test.ts
+++ b/test/integration/comprehensive-generative.test.ts
@@ -5,6 +5,7 @@ import { createMachineServices } from "../../src/language/machine-module.js";
 import { Machine, isMachine } from "../../src/language/generated/ast.js";
 import { generateJSON, generateGraphviz } from "../../src/language/generator/generator.js";
 import { renderDotToSVG } from "../../src/language/diagram/graphviz-generator.js";
+import { base64UrlEncode } from "../../src/utils/url-encoding.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
@@ -246,9 +247,9 @@ class ValidationReporter {
      * Generate a playground link with source code pre-loaded
      */
     private generatePlaygroundLink(source: string): string {
-        // Encode the source code to base64 for URL safety
-        const encoded = Buffer.from(source).toString('base64');
-        return `${this.playgroundUrl}#content=${encodeURIComponent(encoded)}`;
+        // Encode the source code using the shared URL encoding utility
+        const encoded = base64UrlEncode(source);
+        return `${this.playgroundUrl}#content=${encoded}`;
     }
 
     addResult(result: ValidationResult): void {


### PR DESCRIPTION
Updates comprehensive-generative test report to use `base64UrlEncode()` from the shared utility module instead of Buffer-based encoding. This ensures playground links in test reports match the encoding used by CodeEditor and CodeMirrorPlayground components.

## Changes

- Import `base64UrlEncode` from `src/utils/url-encoding.ts`
- Replace `Buffer.from().toString('base64')` + `encodeURIComponent` with `base64UrlEncode()`
- Remove redundant `encodeURIComponent` call (base64UrlEncode already produces URL-safe output)

Fixes consistency issue identified in PR #303 review.

Related: #303

---

Generated with [Claude Code](https://claude.ai/code)