### PR TITLE
fix: Set default collapsed state for settings, files, and execution sections

### DIFF
--- a/src/components/CodeMirrorPlayground.tsx
+++ b/src/components/CodeMirrorPlayground.tsx
@@ -495,11 +495,11 @@ export const CodeMirrorPlayground: React.FC = () => {
   const editorViewRef = useRef<EditorView | null>(null);
 
     const [settings, setSettings] = useState(() => loadSettings());
-    const [settingsCollapsed, setSettingsCollapsed] = useState(false);
-    const [filesCollapsed, setFilesCollapsed] = useState(false);
+    const [settingsCollapsed, setSettingsCollapsed] = useState(true);
+    const [filesCollapsed, setFilesCollapsed] = useState(true);
     const [editorCollapsed, setEditorCollapsed] = useState(false);
     const [outputCollapsed, setOutputCollapsed] = useState(false);
-    const [executionCollapsed, setExecutionCollapsed] = useState(false);
+    const [executionCollapsed, setExecutionCollapsed] = useState(true);
     const [editorSize, setEditorSize] = useState<SectionSize>('medium');
     const [outputSize, setOutputSize] = useState<SectionSize>('medium');
     const [executionSize, setExecutionSize] = useState<SectionSize>('medium');


### PR DESCRIPTION
Fixes #324

## Changes

- Settings, Files, and Execution sections now start collapsed by default
- URL hash params still override defaults when present
- Editor and Output sections remain expanded by default

The playground now provides a cleaner initial view while maintaining full URL state sharing functionality.

---

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/christopherdebeer/machine/actions/runs/18999756829