### PR TITLE
Fix broken links and resources on nested documentation pages

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -23,7 +23,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // Get base URL from environment (Vercel sets VERCEL_BASE_URL, or use VITE_BASE_URL)
-const BASE_URL = process.env.VITE_BASE_URL || process.env.VERCEL_BASE_URL || '/machine/';
+// Default to '/' for production deployment on custom domain (dygram.parc.land)
+const BASE_URL = process.env.VITE_BASE_URL || process.env.VERCEL_BASE_URL || '/';
 // Ensure base URL starts and ends with /
 const normalizedBaseUrl = BASE_URL.startsWith('/') ? BASE_URL : `/${BASE_URL}`;
 const baseUrl = normalizedBaseUrl.endsWith('/') ? normalizedBaseUrl : `${normalizedBaseUrl}/`;
@@ -686,9 +687,9 @@ async function generateEntries(projectRoot) {
             }
         }
 
-        // Calculate relative path to assets from this HTML file
-        const depth = htmlFilePath.split('/').length - projectRoot.split('/').length - 1;
-        const relativeRoot = depth === 0 ? './' : '../'.repeat(depth);
+        // Use absolute paths with base URL for all resources to ensure they work at any nesting level
+        // This prevents 404 errors on child pages like /examples/basic/
+        // Base URL is used in production (e.g., /machine/) and defaults to / in development
 
         // Generate HTML entry
         const htmlContent = `<!DOCTYPE html>
@@ -697,13 +698,13 @@ async function generateEntries(projectRoot) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DyGram | ${page.title}</title>
-    <link rel="stylesheet" href="${relativeRoot}static/styles/main.css">
-    <link rel="stylesheet" href="${relativeRoot}static/styles/carousel.css">
-    <link rel="icon" type="image/jpeg" href="${relativeRoot}icon.jpg">
+    <link rel="stylesheet" href="${baseUrl}static/styles/main.css">
+    <link rel="stylesheet" href="${baseUrl}static/styles/carousel.css">
+    <link rel="icon" type="image/jpeg" href="${baseUrl}icon.jpg">
 </head>
 <body>
     <div id="root"></div>
-    <script type="module" src="/src/pages/${pageName}.tsx"></script>
+    <script type="module" src="${baseUrl}src/pages/${pageName}.tsx"></script>
 </body>
 </html>
 `;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,13 +59,25 @@ function getStaticCopyTargets() {
     ];
 
     // Dynamically scan examples directory and include all subdirectories
+    // Exclude HTML files since they are processed as Vite entry points
     const examplesDir = path.join(__dirname, 'examples');
     if (fs.existsSync(examplesDir)) {
         const exampleContents = fs.readdirSync(examplesDir, { withFileTypes: true });
         for (const item of exampleContents) {
             // Only include directories, not files like index.html
             if (item.isDirectory()) {
-                targets.push({ src: `examples/${item.name}`, dest: 'examples' });
+                const dirPath = path.join(examplesDir, item.name);
+                const filesInDir = fs.readdirSync(dirPath);
+                // Only add copy target if there are non-HTML files
+                const hasNonHtmlFiles = filesInDir.some(f =>
+                    !f.endsWith('.html') && !fs.statSync(path.join(dirPath, f)).isDirectory()
+                );
+                if (hasNonHtmlFiles) {
+                    targets.push({
+                        src: `examples/${item.name}/*.{dy,dygram,mach,machine,json,txt,md}`,
+                        dest: `examples/${item.name}`
+                    });
+                }
             }
         }
     }
@@ -95,7 +107,7 @@ function getStaticCopyTargets() {
 
 export default defineConfig(() => {
     const config = {
-        base: process.env.VITE_BASE_URL || '/machine/',
+        base: process.env.VITE_BASE_URL || '/',
         build: {
             target: 'esnext',
             minify: 'esbuild',


### PR DESCRIPTION
## Problem
Navigation to child pages (e.g., /examples/basic/) resulted in 404 errors for CSS, JS, and icon resources. The site worked correctly on root (/) and first-level pages (/examples/), but failed on nested pages.

## Root Causes
1. Base URL defaulted to '/machine/' instead of '/' for custom domain deployment
2. vite-plugin-static-copy was overwriting Vite-processed HTML files with unprocessed source HTML from examples directories

## Changes
- scripts/prebuild.js: Changed default base URL from '/machine/' to '/'
- vite.config.ts: Changed default base URL from '/machine/' to '/'
- vite.config.ts: Modified static copy to exclude HTML files from examples directories (only copy .dy, .dygram, etc. files)

## Result
All resources now use absolute paths that work at any nesting level. Vite properly processes HTML files and bundles assets without being overwritten by the static copy plugin.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)