### PR TITLE
fix: update Vercel build command to include test reports

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npm run build",
+  "buildCommand": "npm run build:with-tests",
   "outputDirectory": "dist",
   "devCommand": "npm run dev",
   "installCommand": "npm install",


### PR DESCRIPTION
This PR fixes the 404 error on `/test-output/index.html` in Vercel deployments.

## Root Cause
The `vercel.json` was using `npm run build` which doesn't generate test reports. The build command has been changed to `npm run build:with-tests` to ensure the `test-output/` directory is generated and bundled with the static site.

## Changes
- Updated `vercel.json` buildCommand from `npm run build` to `npm run build:with-tests`

## Testing
Verified locally that:
- Test reports are generated in `test-output/`
- Vite correctly copies them to `dist/test-output/`
- The index.html and all report subdirectories are present

Resolves #330

Generated with [Claude Code](https://claude.ai/code)