### PR TITLE
feat: add HTML reporter for Vitest test results

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "@vercel/node": "^5.5.3",
         "@vitejs/plugin-react": "^5.0.4",
         "@vitest/coverage-v8": "^1.6.1",
+        "@vitest/ui": "^1.6.1",
         "@vscode/vsce": "^3.2.1",
         "babel-plugin-styled-components": "^2.1.4",
         "concurrently": "~8.2.1",

--- a/scripts/generate-test-index.js
+++ b/scripts/generate-test-index.js
@@ -23,6 +23,7 @@ const playwrightReportExists = fs.existsSync(path.join(outputDir, 'reports', 'pl
 const coverageReportExists = fs.existsSync(path.join(outputDir, 'coverage', 'index.html'));
 const e2eArtifactsExist = fs.existsSync(path.join(outputDir, 'e2e-artifacts'));
 const vitestReportExists = fs.existsSync(path.join(outputDir, 'vitest', 'junit.xml'));
+const vitestHtmlReportExists = fs.existsSync(path.join(outputDir, 'vitest', 'index.html'));
 const generativeReportExists = fs.existsSync(path.join(outputDir, 'generative', 'index.html'));
 const comprehensiveGenerativeReportExists = fs.existsSync(path.join(outputDir, 'comprehensive-generative', 'index.html'));
 
@@ -226,8 +227,9 @@ const html = `<!DOCTYPE html>
 
             <div class="report-card">
                 <h2><span class="icon">✅</span> Unit Test Results <span class="badge">Vitest</span></h2>
-                <p>Unit and integration test results in JUnit XML format for CI/CD integration.</p>
+                <p>Unit and integration test results in HTML and JUnit XML format for CI/CD integration.</p>
                 <ul>
+                    <li>🌐 ${vitestHtmlReportExists ? '<a href="vitest/index.html">HTML Test Report</a>' : '<span class="unavailable">HTML Test Report</span>'} ${vitestHtmlReportExists ? '<span class="status available">✓</span>' : '<span class="status unavailable">Not Generated</span>'}</li>
                     <li>📄 ${vitestReportExists ? '<a href="vitest/junit.xml">JUnit XML Report</a>' : '<span class="unavailable">JUnit XML Report</span>'} ${vitestReportExists ? '<span class="status available">✓</span>' : '<span class="status unavailable">Not Generated</span>'}</li>
                 </ul>
             </div>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,9 +38,10 @@ export default defineConfig({
         },
         include: ['**/*.test.ts'],
         exclude: ['**/e2e/**', '**/node_modules/**'],
-        reporters: ['default', 'junit'],
+        reporters: ['default', 'junit', 'html'],
         outputFile: {
-            junit: 'test-output/vitest/junit.xml'
+            junit: 'test-output/vitest/junit.xml',
+            html: 'test-output/vitest/index.html'
         },
         // Ensure langium files are generated before tests run
         globalSetup: ['./test/setup/vitest-setup.ts']


### PR DESCRIPTION
Add HTML reporting for Vitest test results alongside existing XML reports.

## Changes
- Added `@vitest/ui` dependency for HTML reporting
- Configure Vitest to generate HTML reports at `test-output/vitest/index.html`
- Updated test output index to link to HTML reports
- Retained all existing reports (coverage, XML, Playwright)
- HTML reports automatically included in `dist/test-output` via vite.config.ts

Resolves #335

Generated with [Claude Code](https://claude.ai/code)