### PR TITLE
style: apply DyGram brand styling to root test outputs index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
                 "@vercel/node": "^5.5.3",
                 "@vitejs/plugin-react": "^5.0.4",
                 "@vitest/coverage-v8": "^1.6.1",
+                "@vitest/ui": "^1.6.1",
                 "@vscode/vsce": "^3.2.1",
                 "babel-plugin-styled-components": "^2.1.4",
                 "concurrently": "~8.2.1",
@@ -3090,6 +3091,13 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@polka/url": {
+            "version": "1.0.0-next.29",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+            "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-beta.38",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz",
@@ -5331,6 +5339,35 @@
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
+        },
+        "node_modules/@vitest/ui": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-1.6.1.tgz",
+            "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "1.6.1",
+                "fast-glob": "^3.3.2",
+                "fflate": "^0.8.1",
+                "flatted": "^3.2.9",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "sirv": "^2.0.4"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "vitest": "1.6.1"
+            }
+        },
+        "node_modules/@vitest/ui/node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@vitest/utils": {
             "version": "1.6.1",
@@ -8274,6 +8311,13 @@
             "dependencies": {
                 "pend": "~1.2.0"
             }
+        },
+        "node_modules/fflate": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
@@ -11548,6 +11592,16 @@
                 "node": ">=4"
             }
         },
+        "node_modules/mrmime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+            "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13484,6 +13538,21 @@
                 "simple-concat": "^1.0.0"
             }
         },
+        "node_modules/sirv": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+            "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.24",
+                "mrmime": "^2.0.0",
+                "totalist": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/sitemap": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.1.tgz",
@@ -14262,6 +14331,16 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/totalist": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+            "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/tr46": {

--- a/scripts/generate-test-index.js
+++ b/scripts/generate-test-index.js
@@ -41,10 +41,10 @@ const html = `<!DOCTYPE html>
         }
 
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            font-family: 'Space Mono', monospace, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             line-height: 1.6;
-            color: #333;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #0F0F0F;
+            background: #F7F7F7;
             min-height: 100vh;
             padding: 2rem;
         }
@@ -53,19 +53,20 @@ const html = `<!DOCTYPE html>
             max-width: 1200px;
             margin: 0 auto;
             background: white;
-            border-radius: 12px;
-            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
             padding: 3rem;
         }
 
         h1 {
-            color: #667eea;
+            color: #0F0F0F;
             margin-bottom: 0.5rem;
             font-size: 2.5rem;
+            font-weight: 700;
         }
 
         .subtitle {
-            color: #666;
+            color: #303030;
             margin-bottom: 3rem;
             font-size: 1.1rem;
         }
@@ -78,30 +79,51 @@ const html = `<!DOCTYPE html>
         }
 
         .report-card {
-            border: 2px solid #e0e0e0;
-            border-radius: 8px;
+            border: 2px solid #0F0F0F;
+            border-left: 8px solid #FF5E5B;
+            border-radius: 4px;
             padding: 1.5rem;
-            transition: all 0.3s ease;
-            background: #fafafa;
+            transition: all 0.2s;
+            background: #F7F7F7;
         }
 
         .report-card:hover {
-            border-color: #667eea;
-            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
+            background: #303030;
+            color: white;
             transform: translateY(-2px);
         }
 
+        .report-card:hover h2,
+        .report-card:hover p,
+        .report-card:hover .icon {
+            color: white;
+        }
+
+        .report-card:hover a {
+            color: #FF5E5B;
+        }
+
+        .report-card:hover a.unavailable {
+            color: #999;
+        }
+
+        .report-card:hover .status {
+            background: #FF5E5B;
+            color: white;
+        }
+
         .report-card h2 {
-            color: #333;
+            color: #0F0F0F;
             margin-bottom: 1rem;
             font-size: 1.5rem;
+            font-weight: 600;
             display: flex;
             align-items: center;
             gap: 0.5rem;
         }
 
         .report-card p {
-            color: #666;
+            color: #303030;
             margin-bottom: 1rem;
         }
 
@@ -115,14 +137,13 @@ const html = `<!DOCTYPE html>
         }
 
         .report-card a {
-            color: #667eea;
+            color: #FF5E5B;
             text-decoration: none;
-            font-weight: 500;
-            transition: color 0.3s ease;
+            font-weight: 600;
+            transition: all 0.2s;
         }
 
         .report-card a:hover {
-            color: #764ba2;
             text-decoration: underline;
         }
 
@@ -137,40 +158,62 @@ const html = `<!DOCTYPE html>
         }
 
         .info-section {
-            background: #f0f4ff;
-            border-left: 4px solid #667eea;
+            background: #F7F7F7;
+            border-left: 8px solid #FF5E5B;
             padding: 1.5rem;
             border-radius: 4px;
             margin-bottom: 2rem;
         }
 
         .info-section h3 {
-            color: #667eea;
+            color: #0F0F0F;
             margin-bottom: 0.5rem;
+            font-weight: 600;
         }
 
         .info-section p {
-            color: #555;
+            color: #303030;
             margin-bottom: 0.5rem;
+        }
+
+        .info-section code {
+            background: #1A1A1A;
+            color: #F7F7F7;
+            padding: 0.25rem 0.5rem;
+            border-radius: 3px;
+            font-family: 'Courier New', 'Fira Code', monospace;
+            font-size: 0.9rem;
         }
 
         footer {
             text-align: center;
-            color: #999;
+            color: #303030;
             margin-top: 3rem;
             padding-top: 2rem;
-            border-top: 1px solid #e0e0e0;
+            border-top: 2px solid #0F0F0F;
+        }
+
+        footer a {
+            color: #FF5E5B;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        footer a:hover {
+            text-decoration: underline;
         }
 
         .badge {
             display: inline-block;
             padding: 0.25rem 0.75rem;
-            background: #667eea;
+            background: #0F0F0F;
             color: white;
-            border-radius: 12px;
+            border-radius: 4px;
             font-size: 0.875rem;
             font-weight: 600;
             margin-left: 0.5rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
         }
 
         .status {
@@ -180,16 +223,75 @@ const html = `<!DOCTYPE html>
             font-size: 0.75rem;
             font-weight: 600;
             margin-left: 0.5rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
         }
 
         .status.available {
-            background: #d4edda;
-            color: #155724;
+            background: #4caf50;
+            color: white;
         }
 
         .status.unavailable {
-            background: #f8d7da;
-            color: #721c24;
+            background: #FF5E5B;
+            color: white;
+        }
+
+        /* Mobile responsive adjustments */
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            .container {
+                padding: 1.5rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .subtitle {
+                font-size: 1rem;
+            }
+
+            .report-grid {
+                grid-template-columns: 1fr;
+                gap: 1.5rem;
+            }
+
+            .report-card {
+                padding: 1rem;
+            }
+
+            .report-card h2 {
+                font-size: 1.25rem;
+            }
+
+            .info-section {
+                padding: 1rem;
+            }
+        }
+
+        @media (max-width: 480px) {
+            h1 {
+                font-size: 1.75rem;
+            }
+
+            .subtitle {
+                font-size: 0.9rem;
+            }
+
+            .report-card h2 {
+                font-size: 1.1rem;
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .badge {
+                margin-left: 0;
+                margin-top: 0.5rem;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
Applies consistent DyGram brand styling to the root test outputs index.

Follows up on #336 to ensure all test reports have a cohesive design language.

## Changes
- Updated `scripts/generate-test-index.js` with DyGram brand colors and styling
- Replaced purple gradient theme with dark/coral red aesthetic
- Added Space Mono typography throughout
- Implemented 8px accent borders on cards and sections
- Added hover effects with accent color transitions
- Styled code blocks with dark background
- Added mobile responsive optimizations

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/christopherdebeer/machine/actions/runs/19005135652) | [View branch](https://github.com/christopherdebeer/machine/tree/claude/pr-336-20251102-0058