### PR TITLE
feat: Add copy and fit toggle buttons to CodeEditor

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -434,8 +434,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
                                 ref={outputRef}
                                 className="output"
                                 $fitToView={fitToView}
-                                dangerouslySetInnerHTML={{ __html: outputSvg }}
                             >
+                                <div dangerouslySetInnerHTML={{ __html: outputSvg }} />
                                 <OverlayButtonGroup>
                                     <OverlayButton
                                         onClick={() => setFitToView(!fitToView)}
@@ -462,8 +462,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
                         ref={outputRef}
                         className="output"
                         $fitToView={fitToView}
-                        dangerouslySetInnerHTML={{ __html: outputSvg }}
                     >
+                        <div dangerouslySetInnerHTML={{ __html: outputSvg }} />
                         <OverlayButtonGroup>
                             <OverlayButton
                                 onClick={() => setFitToView(!fitToView)}
@@ -509,8 +509,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
                                 className="output"
                                 $fitToView={fitToView}
                                 style={{ flex: '1 1 45%' }}
-                                dangerouslySetInnerHTML={{ __html: outputSvg }}
                             >
+                                <div dangerouslySetInnerHTML={{ __html: outputSvg }} />
                                 <OverlayButtonGroup>
                                     <OverlayButton
                                         onClick={() => setFitToView(!fitToView)}
@@ -584,8 +584,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
                                 ref={outputRef}
                                 className="output"
                                 $fitToView={fitToView}
-                                dangerouslySetInnerHTML={{ __html: outputSvg }}
                             >
+                                <div dangerouslySetInnerHTML={{ __html: outputSvg }} />
                                 <OverlayButtonGroup>
                                     <OverlayButton
                                         onClick={() => setFitToView(!fitToView)}


### PR DESCRIPTION
Add layer of polish and refinement to CodeEditor component:

- Add copy button to code view (copies source to clipboard)
- Add copy button to visual view (copies SVG as PNG image)
- Add fit toggle button to visual view (toggles between fit-to-width and natural size)
- Style buttons as subtle overlays in top-right corner
- Show success feedback with green background for 2 seconds
- Support all display modes (code-only, visual-only, split, toggle)

Buttons use semi-transparent backgrounds and smooth transitions for a polished UX.

Fixes #358

🤖 Generated with [Claude Code](https://claude.ai/code)