### PR TITLE
Fix: Invalidate cached executor when API key or model changes

### DIFF
--- a/src/components/CodeMirrorPlayground.tsx
+++ b/src/components/CodeMirrorPlayground.tsx
@@ -742,6 +742,8 @@ export const CodeMirrorPlayground: React.FC = () => {
         saveSettings(updated.model, updated.apiKey);
         return updated;
       });
+      // Invalidate cached executor when model changes
+      setExecutor(null);
     },
     []
   );
@@ -754,6 +756,8 @@ export const CodeMirrorPlayground: React.FC = () => {
         saveSettings(updated.model, updated.apiKey);
         return updated;
       });
+      // Invalidate cached executor when API key changes
+      setExecutor(null);
     },
     []
   );


### PR DESCRIPTION
## Summary

Fixed issue where the CodeMirror playground continued using mock responses even after setting a valid API key.

## Root Cause

The playground caches the `RailsExecutor` instance for reuse, but when users changed API key or model settings, the cached executor was not invalidated. This caused it to continue using the old (possibly empty) API key.

## Changes

- Added `setExecutor(null)` to `handleApiKeyChange` (line 758)
- Added `setExecutor(null)` to `handleModelChange` (line 746)
- Ensures fresh executor is created with current settings on next execution

Fixes #367

🤖 Generated with [Claude Code](https://claude.ai/code)